### PR TITLE
feat: トークテーマカテゴリー一覧のjsonデータを取得できるようにする。

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -57,3 +57,4 @@ gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
 gem 'devise'
 gem 'seed-fu'
+gem "active_model_serializers"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -39,6 +39,11 @@ GEM
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.1, >= 1.2.0)
+    active_model_serializers (0.10.13)
+      actionpack (>= 4.1, < 7.1)
+      activemodel (>= 4.1, < 7.1)
+      case_transform (>= 0.2)
+      jsonapi-renderer (>= 0.1.1.beta1, < 0.3)
     activejob (6.1.7)
       activesupport (= 6.1.7)
       globalid (>= 0.3.6)
@@ -77,6 +82,8 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    case_transform (0.2)
+      activesupport
     childprocess (4.1.0)
     concurrent-ruby (1.1.10)
     crass (1.0.6)
@@ -95,6 +102,7 @@ GEM
     jbuilder (2.11.5)
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
+    jsonapi-renderer (0.2.2)
     listen (3.7.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -223,6 +231,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  active_model_serializers
   bootsnap (>= 1.4.4)
   byebug
   capybara (>= 3.26)

--- a/app/assets/stylesheets/admin/api/v1/categories.scss
+++ b/app/assets/stylesheets/admin/api/v1/categories.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the admin/api/v1/categories controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: https://sass-lang.com/

--- a/app/controllers/admin/api/v1/categories_controller.rb
+++ b/app/controllers/admin/api/v1/categories_controller.rb
@@ -1,4 +1,13 @@
 class Admin::Api::V1::CategoriesController < ApiController
+  before_action :authenticate_admin!
+
+  # ActiveRecordのレコードが見つからなければ404 not foundを応答する
+  rescue_from ActiveRecord::RecordNotFound do |exception|
+    render json: { error: '404 not found' }, status: 404
+  end
+
   def index
+    categories = Category.all
+    render json: categories
   end
 end

--- a/app/controllers/admin/api/v1/categories_controller.rb
+++ b/app/controllers/admin/api/v1/categories_controller.rb
@@ -1,0 +1,4 @@
+class Admin::Api::V1::CategoriesController < ApiController
+  def index
+  end
+end

--- a/app/controllers/api/v1/categories_controller.rb
+++ b/app/controllers/api/v1/categories_controller.rb
@@ -1,4 +1,4 @@
-class Admin::Api::V1::CategoriesController < ApiController
+class Api::V1::CategoriesController < ApiController
   before_action :authenticate_admin!
 
   # ActiveRecordのレコードが見つからなければ404 not foundを応答する

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -1,0 +1,2 @@
+class ApiController < ActionController::API
+end

--- a/app/helpers/admin/api/v1/categories_helper.rb
+++ b/app/helpers/admin/api/v1/categories_helper.rb
@@ -1,0 +1,2 @@
+module Admin::Api::V1::CategoriesHelper
+end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,0 +1,3 @@
+class Category < ApplicationRecord
+  validates :name, presence: true
+end

--- a/app/serializers/category_serializer.rb
+++ b/app/serializers/category_serializer.rb
@@ -1,0 +1,3 @@
+class CategorySerializer < ActiveModel::Serializer
+  attributes :id, :name
+end

--- a/app/views/admin/api/v1/categories/index.html.erb
+++ b/app/views/admin/api/v1/categories/index.html.erb
@@ -1,0 +1,2 @@
+<h1>Admin::Api::V1::Categories#index</h1>
+<p>Find me in app/views/admin/api/v1/categories/index.html.erb</p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,15 +1,13 @@
 Rails.application.routes.draw do
-  namespace :admin do
-    namespace :api do
-      namespace :v1 do
-        get 'categories/index'
-      end
-    end
-  end
   devise_for :admin, skip: [:registrations, :passwords] ,controllers: {
     sessions: "admin/sessions"
   }
   namespace :admin do
     resources :talk_themes, only: [:index, :create, :edit, :update, :destroy]
+    namespace :api, {format: 'json'} do
+      namespace :v1 do
+        resources :categories, only: [:index, :create, :edit, :update, :destroy]
+      end
+    end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,10 +4,10 @@ Rails.application.routes.draw do
   }
   namespace :admin do
     resources :talk_themes, only: [:index, :create, :edit, :update, :destroy]
-    namespace :api, {format: 'json'} do
-      namespace :v1 do
-        resources :categories, only: [:index, :create, :edit, :update, :destroy]
-      end
+  end
+  namespace :api, {format: 'json'} do
+    namespace :v1 do
+      resources :categories, only: [:index, :create, :edit, :update, :destroy]
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,11 @@
 Rails.application.routes.draw do
+  namespace :admin do
+    namespace :api do
+      namespace :v1 do
+        get 'categories/index'
+      end
+    end
+  end
   devise_for :admin, skip: [:registrations, :passwords] ,controllers: {
     sessions: "admin/sessions"
   }

--- a/db/migrate/20220928033939_create_categories.rb
+++ b/db/migrate/20220928033939_create_categories.rb
@@ -1,0 +1,9 @@
+class CreateCategories < ActiveRecord::Migration[6.1]
+  def change
+    create_table :categories do |t|
+      t.string :name, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_09_27_090619) do
+ActiveRecord::Schema.define(version: 2022_09_28_033939) do
 
   create_table "admins", force: :cascade do |t|
     t.string "email", default: "", null: false
@@ -22,6 +22,12 @@ ActiveRecord::Schema.define(version: 2022_09_27_090619) do
     t.datetime "updated_at", precision: 6, null: false
     t.index ["email"], name: "index_admins_on_email", unique: true
     t.index ["reset_password_token"], name: "index_admins_on_reset_password_token", unique: true
+  end
+
+  create_table "categories", force: :cascade do |t|
+    t.string "name", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
 end

--- a/test/controllers/admin/api/v1/categories_controller_test.rb
+++ b/test/controllers/admin/api/v1/categories_controller_test.rb
@@ -1,0 +1,8 @@
+require "test_helper"
+
+class Admin::Api::V1::CategoriesControllerTest < ActionDispatch::IntegrationTest
+  test "should get index" do
+    get admin_api_v1_categories_index_url
+    assert_response :success
+  end
+end

--- a/test/fixtures/categories.yml
+++ b/test/fixtures/categories.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/models/category_test.rb
+++ b/test/models/category_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class CategoryTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## 変更の概要
トークテーマカテゴリー一覧のjsonデータを取得できるようにする。

## なぜこの変更をするのか
トークテーマカテゴリー一覧をjsonデータにすることによって、Vue.jsで扱えるようにするため。

## やったこと
1.  関するモデル・コントローラを作成する。
2.  関するアクション・ルーティングを設定する。
3.  アクション内にrender jsonを記述し、返り値をjsonデータにする。

## 関連issue
- #3  