### PR TITLE
feat: 管理者専用画面にトークテーマカテゴリー一覧画面を追加し、それらを管理できるようにする。

### DIFF
--- a/app/assets/stylesheets/admin/categories.scss
+++ b/app/assets/stylesheets/admin/categories.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the admin/categories controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: https://sass-lang.com/

--- a/app/controllers/admin/categories_controller.rb
+++ b/app/controllers/admin/categories_controller.rb
@@ -1,0 +1,4 @@
+class Admin::CategoriesController < ApplicationController
+  def index
+  end
+end

--- a/app/controllers/admin/categories_controller.rb
+++ b/app/controllers/admin/categories_controller.rb
@@ -22,6 +22,12 @@ class Admin::CategoriesController < ApplicationController
     redirect_to admin_categories_path
   end
 
+  def destroy
+    category = Category.find(params[:id]) 
+    category.destroy
+    redirect_to admin_categories_path
+  end
+
   private
   def category_params
     params.require(:category).permit(:name)

--- a/app/controllers/admin/categories_controller.rb
+++ b/app/controllers/admin/categories_controller.rb
@@ -18,8 +18,11 @@ class Admin::CategoriesController < ApplicationController
 
   def update
     @category = Category.find(params[:id])
-    @category.update(category_params)
-    redirect_to admin_categories_path
+    if @category.update(category_params)
+      redirect_to admin_categories_path
+    else
+      render :edit
+    end
   end
 
   def destroy

--- a/app/controllers/admin/categories_controller.rb
+++ b/app/controllers/admin/categories_controller.rb
@@ -12,6 +12,16 @@ class Admin::CategoriesController < ApplicationController
     redirect_to admin_categories_path
   end
 
+  def edit
+    @category = Category.find(params[:id])
+  end
+
+  def update
+    @category = Category.find(params[:id])
+    @category.update(category_params)
+    redirect_to admin_categories_path
+  end
+
   private
   def category_params
     params.require(:category).permit(:name)

--- a/app/controllers/admin/categories_controller.rb
+++ b/app/controllers/admin/categories_controller.rb
@@ -1,4 +1,19 @@
 class Admin::CategoriesController < ApplicationController
+  before_action :authenticate_admin!
+
   def index
+    @categories = Category.all
+    @category = Category.new
+  end
+
+  def create
+    @category = Category.new(category_params)
+    @category.save
+    redirect_to admin_categories_path
+  end
+
+  private
+  def category_params
+    params.require(:category).permit(:name)
   end
 end

--- a/app/helpers/admin/categories_helper.rb
+++ b/app/helpers/admin/categories_helper.rb
@@ -1,0 +1,2 @@
+module Admin::CategoriesHelper
+end

--- a/app/views/admin/categories/edit.html.erb
+++ b/app/views/admin/categories/edit.html.erb
@@ -1,0 +1,13 @@
+<h1>Editing Category</h1>
+
+<%= form_with model: @category, url: admin_category_path(@category) do |f| %>
+<div class="field">
+  <label for="category_name">Name</label>
+  <%= f.text_field :name %>
+</div>
+<div class="actions">
+  <%= f.submit 'カテゴリーを更新' %>
+</div>
+<% end %>
+
+<%= link_to "Back", admin_categories_path %>

--- a/app/views/admin/categories/index.html.erb
+++ b/app/views/admin/categories/index.html.erb
@@ -1,0 +1,2 @@
+<h1>Admin::Categories#index</h1>
+<p>Find me in app/views/admin/categories/index.html.erb</p>

--- a/app/views/admin/categories/index.html.erb
+++ b/app/views/admin/categories/index.html.erb
@@ -1,2 +1,30 @@
-<h1>Admin::Categories#index</h1>
-<p>Find me in app/views/admin/categories/index.html.erb</p>
+<h1>Categories</h1>
+<table>
+  <thead>
+    <tr>
+      <th>カテゴリー名</th>
+      <th colspan="2"></th>
+    </tr>
+  </thead>
+  <tbody>
+    <% @categories.each do |category| %>
+    <tr>
+      <td><%= category.name %></td>
+      <td><%= link_to "edit", edit_admin_category_path(category) %></td>
+      <td>
+        <%= link_to "Destroy", admin_category_path(category), method: :delete, "data-confirm" => "本当に「#{category.name}」を消しますか？" %>
+      </td>
+    </tr>
+    <% end %>
+  </tbody>
+</table>
+
+<%= form_with model: @category, url: admin_categories_path do |f| %>
+  <div class="field">
+    <label for="category_name">Title</label>
+    <%= f.text_field :name %>
+  </div>
+  <div class="actions">
+    <%= f.submit 'カテゴリーを作成' %>
+  </div>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,11 +1,9 @@
 Rails.application.routes.draw do
-  namespace :admin do
-    get 'categories/index'
-  end
   devise_for :admin, skip: [:registrations, :passwords] ,controllers: {
     sessions: "admin/sessions"
   }
   namespace :admin do
+    resources :categories, only: [:index, :create, :edit, :update, :destroy]
     resources :talk_themes, only: [:index, :create, :edit, :update, :destroy]
   end
   namespace :api, {format: 'json'} do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,7 @@
 Rails.application.routes.draw do
+  namespace :admin do
+    get 'categories/index'
+  end
   devise_for :admin, skip: [:registrations, :passwords] ,controllers: {
     sessions: "admin/sessions"
   }

--- a/test/controllers/admin/categories_controller_test.rb
+++ b/test/controllers/admin/categories_controller_test.rb
@@ -1,0 +1,8 @@
+require "test_helper"
+
+class Admin::CategoriesControllerTest < ActionDispatch::IntegrationTest
+  test "should get index" do
+    get admin_categories_index_url
+    assert_response :success
+  end
+end


### PR DESCRIPTION
## 変更の概要
管理者専用画面にトークテーマカテゴリー一覧画面を追加し、それらを管理できるようにする。

## なぜこの変更をするのか
管理者がトークテーマカテゴリーの作成、編集、削除をこのサイト内で、できるようにするため。

## やったこと
1. admin/categoriesコントローラを作成し、関するアクションを作成する。
2. 関するルーティングを設定する。
3. admin/categoriesのindex.html.erbを作成し、トークテーマカテゴリー一覧表示、トークテーマカテゴリー新規作成フォーム、編集・削除ボタンを追加する。

## 関連issue
- #5 