### PR TITLE
feat: admin/talk_themesコントローラをapi化し、apiのフォルダに移動させる

### DIFF
--- a/app/controllers/admin/talk_themes_controller.rb
+++ b/app/controllers/admin/talk_themes_controller.rb
@@ -1,4 +1,4 @@
-class Admin::TalkThemesController < ApplicationController
+class Admin::TalkThemesController < ApiController
   before_action :authenticate_admin!
   
   def index

--- a/app/controllers/api/v1/talk_themes_controller.rb
+++ b/app/controllers/api/v1/talk_themes_controller.rb
@@ -1,4 +1,4 @@
-class Admin::TalkThemesController < ApiController
+class Api::V1::TalkThemesController < ApiController
   before_action :authenticate_admin!
   
   def index


### PR DESCRIPTION
## 変更の概要
admin/talk_themesコントローラをapi化し、apiのフォルダに移動させる。

## なぜこの変更をするのか
Vue.jsでトークテーマのデータを扱うため。

## やったこと
1. 既に作成しているadmin/talk_themesコントローラの継承をApiControllerに変更する。
2. そのコントローラをapi/v1フォルダに移動させる。

## 関連issue
- #6 