### PR TITLE
feat: 管理者専用画面のトークテーマ一覧画面でトークテーマをカテゴリー別に表示する。

### DIFF
--- a/app/controllers/api/v1/categories_controller.rb
+++ b/app/controllers/api/v1/categories_controller.rb
@@ -8,7 +8,7 @@ class Api::V1::CategoriesController < ApiController
 
   def index
     categories = Category.all
-    render json: categories, each_serializer: CategorySerializer
+    render json: categories, each_serializer: CategorySerializer, include: [ :talk_themes ]
   end
 
   def create

--- a/app/controllers/api/v1/categories_controller.rb
+++ b/app/controllers/api/v1/categories_controller.rb
@@ -7,7 +7,7 @@ class Api::V1::CategoriesController < ApiController
   end
 
   def index
-    categories = Category.all
+    categories = Category.preload(:talk_themes).all
     render json: categories, each_serializer: CategorySerializer, include: [ :talk_themes ]
   end
 

--- a/app/javascript/admin/ContentIndexPage.vue
+++ b/app/javascript/admin/ContentIndexPage.vue
@@ -1,31 +1,28 @@
 <template>
-  <table>
-    <tbody>
-      <tr>
-        <th>content</th>
-      </tr>
-      <tr v-for="talk_theme in talk_themes" :key="talk_theme.id">
-        <td>{{ talk_theme.content }}</td>
-      </tr>
-    </tbody>
-  </table>
+  <h2>content</h2>
+  <div v-for="category in categories" :key="category.id">
+    <h3>{{ category.name }}</h3>
+    <div v-for="talk_theme in category.talk_themes" :key="talk_theme.id">
+      {{ talk_theme.content }}
+    </div>
+  </div>
 </template>
 
 <script>
-import axios from 'axios';
+import axios from "axios";
 
 export default {
   data() {
     return {
-      talk_themes: []
-    }
+      categories: {},
+    };
   },
   mounted() {
     axios
-      .get('/api/v1/talk_themes.json')
-      .then(response => (this.talk_themes = response.data))
-  }
-}
+      .get("/api/v1/categories")
+      .then((response) => (this.categories = response.data));
+  },
+};
 </script>
 
 <style scoped>

--- a/app/serializers/category_serializer.rb
+++ b/app/serializers/category_serializer.rb
@@ -1,3 +1,5 @@
 class CategorySerializer < ActiveModel::Serializer
   attributes :id, :name
+
+  has_many :talk_themes
 end


### PR DESCRIPTION
## 変更の概要
管理者専用画面のトークテーマ一覧画面でトークテーマをカテゴリー別に表示する。

## なぜこの変更をするのか
トークテーマを各カテゴリ－ごとに分けて表示し、管理しやすくするため。

## やったこと
1. rails apiで各カテゴリーに関連付けられたトークテーマのデータを取得する。
2. そのデータを繰り返し処理により、各カテゴリーごとに表示する。

## 関連issue
- #16 
