### PR TITLE
feat: 管理者専用画面にトークテーマ・カテゴリー編集画面を追加する。

### DIFF
--- a/app/controllers/api/v1/categories_controller.rb
+++ b/app/controllers/api/v1/categories_controller.rb
@@ -1,5 +1,6 @@
 class Api::V1::CategoriesController < ApiController
   before_action :authenticate_admin!
+  before_action :set_category, only: [:show, :update]
 
   # ActiveRecordのレコードが見つからなければ404 not foundを応答する
   rescue_from ActiveRecord::RecordNotFound do |exception|
@@ -11,6 +12,10 @@ class Api::V1::CategoriesController < ApiController
     render json: categories, each_serializer: CategorySerializer, include: [ :talk_themes ]
   end
 
+  def show
+    render json: @category
+  end
+
   def create
     category =  Category.new(category_params)
     if category.save
@@ -20,7 +25,19 @@ class Api::V1::CategoriesController < ApiController
     end
   end
 
+  def update
+    if @category.update(category_params)
+      head :no_content
+    else
+      render json: { errors: category.errors.full_messages }, status: :unprocessable_entity
+    end
+  end
+
   private
+    def set_category
+      @category = Category.find(params[:id])
+    end
+
     def category_params
       params.require(:category).permit(:name)
     end

--- a/app/controllers/api/v1/talk_themes_controller.rb
+++ b/app/controllers/api/v1/talk_themes_controller.rb
@@ -1,5 +1,6 @@
 class Api::V1::TalkThemesController < ApiController
   before_action :authenticate_admin!
+  before_action :set_talk_theme, only: [:show, :update]
   
   # ActiveRecordのレコードが見つからなければ404 not foundを応答する
   rescue_from ActiveRecord::RecordNotFound do |exception|
@@ -11,6 +12,10 @@ class Api::V1::TalkThemesController < ApiController
     render json: talk_themes, each_serializer: TalkThemeSerializer
   end
 
+  def show
+    render json: @talk_theme
+  end
+
   def create
     talk_theme =  TalkTheme.new(talk_theme_params)
     if talk_theme.save
@@ -20,7 +25,19 @@ class Api::V1::TalkThemesController < ApiController
     end
   end
 
+  def update
+    if @talk_theme.update(talk_theme_params)
+      head :no_content
+    else
+      render json: { errors: talk_theme.errors.full_messages }, status: :unprocessable_entity
+    end
+  end
+
   private
+    def set_talk_theme
+      @talk_theme = TalkTheme.find(params[:id])
+    end
+
     def talk_theme_params
       params.require(:talk_theme).permit(:content, :category_id)
     end

--- a/app/javascript/admin/CategoryEditPage.vue
+++ b/app/javascript/admin/CategoryEditPage.vue
@@ -1,0 +1,7 @@
+<template>
+</template>
+
+<script>
+</script>
+
+<style scoped></style>

--- a/app/javascript/admin/CategoryEditPage.vue
+++ b/app/javascript/admin/CategoryEditPage.vue
@@ -1,7 +1,50 @@
 <template>
+  <form @submit.prevent="updateCategory">
+    <div v-if="errors.length != 0">
+      <ul v-for="error in errors" :key="error">
+        <li>
+          <font color="red">{{ error }}</font>
+        </li>
+      </ul>
+    </div>
+    <div>
+      <input v-model="category.name" type="text" />
+    </div>
+    <button type="submit">カテゴリーを更新</button>
+  </form>
 </template>
 
 <script>
+import axios from 'axios';
+
+export default {
+  data() {
+    return {
+      category: {},
+      errors: ''
+    }
+  },
+  mounted () {
+    axios
+      .get(`/api/v1/categories/${this.$route.params.id}`)
+      .then(response => (this.category = response.data))
+  },
+  methods: {
+    updateCategory: function() {
+      axios
+        .patch(`/api/v1/categories/${this.category.id}`, this.category)
+        .then(() => {
+          this.$router.push({ path: "/" });
+        })
+        .catch(error => {
+          console.error(error);
+          if (error.response.data && error.response.data.errors) {
+            this.errors = error.response.data.errors;
+          }
+        });
+    }
+  }
+}
 </script>
 
 <style scoped></style>

--- a/app/javascript/admin/ContentIndexPage.vue
+++ b/app/javascript/admin/ContentIndexPage.vue
@@ -1,7 +1,7 @@
 <template>
   <h2>content</h2>
   <div v-for="category in categories" :key="category.id">
-    <h3>{{ category.name }}</h3>
+    <h3>{{ category.name }} <router-link :to="{ name: 'CategoryEditPage', params: { id: category.id } }">編集</router-link></h3>
     <div v-for="talk_theme in category.talk_themes" :key="talk_theme.id">
       {{ talk_theme.content }}
     </div>

--- a/app/javascript/admin/ContentIndexPage.vue
+++ b/app/javascript/admin/ContentIndexPage.vue
@@ -3,7 +3,7 @@
   <div v-for="category in categories" :key="category.id">
     <h3>{{ category.name }} <router-link :to="{ name: 'CategoryEditPage', params: { id: category.id } }">編集</router-link></h3>
     <div v-for="talk_theme in category.talk_themes" :key="talk_theme.id">
-      {{ talk_theme.content }}
+      {{ talk_theme.content }} <router-link :to="{ name: 'TalkThemeEditPage', params: { id: talk_theme.id } }">編集</router-link>
     </div>
   </div>
 </template>

--- a/app/javascript/admin/TalkThemeEditPage.vue
+++ b/app/javascript/admin/TalkThemeEditPage.vue
@@ -1,0 +1,7 @@
+<template>
+</template>
+
+<script>
+</script>
+
+<style scoped></style>

--- a/app/javascript/admin/TalkThemeEditPage.vue
+++ b/app/javascript/admin/TalkThemeEditPage.vue
@@ -1,7 +1,64 @@
 <template>
+  <form @submit.prevent="updateTalkTheme">
+    <div v-if="errors.length != 0">
+      <ul v-for="error in errors" :key="error">
+        <li>
+          <font color="red">{{ error }}</font>
+        </li>
+      </ul>
+    </div>
+    <div><input v-model="talk_theme.content" type="text" /> ?</div>
+    <div>
+      <select v-model="talk_theme.category_id">
+        <option disabled value="">選択してください</option>
+        <option
+          v-for="category in categories"
+          :value="category.id"
+          :key="category.id"
+        >
+          {{ category.name }}
+        </option>
+      </select>
+    </div>
+    <button type="submit">トークテーマを更新</button>
+  </form>
 </template>
 
 <script>
+import axios from "axios";
+
+export default {
+  data() {
+    return {
+      talk_theme: {},
+      categories: {},
+      errors: "",
+    };
+  },
+  mounted() {
+    axios
+      .get(`/api/v1/talk_themes/${this.$route.params.id}`)
+      .then((response) => (this.talk_theme = response.data));
+    axios
+      .get("/api/v1/categories")
+      .then((response) => (this.categories = response.data));
+  },
+  methods: {
+    updateTalkTheme: function () {
+      axios
+        .patch(`/api/v1/talk_themes/${this.talk_theme.id}`, this.talk_theme)
+        .then(() => {
+          this.$router.push({ path: "/" });
+        })
+        .catch((error) => {
+          console.error(error);
+          if (error.response.data && error.response.data.errors) {
+            this.errors = error.response.data.errors;
+          }
+        });
+    },
+  },
+};
 </script>
 
 <style scoped></style>

--- a/app/javascript/packs/router.js
+++ b/app/javascript/packs/router.js
@@ -1,12 +1,16 @@
 import { createRouter, createWebHashHistory } from "vue-router";
 import ContentIndexPage from "../admin/ContentIndexPage.vue";
 import ContentNewPage from "../admin/ContentNewPage.vue";
+import CategoryEditPage from "../admin/CategoryEditPage.vue";
 
 const routes = [
   { path: "/", 
     component: ContentIndexPage },
   { path: "/homes/new", 
     component: ContentNewPage },
+  { path: '/categories/:id(\\d+)/edit',
+    name: 'CategoryEditPage',
+    component: CategoryEditPage  }
 ]
 
 const router = createRouter({

--- a/app/javascript/packs/router.js
+++ b/app/javascript/packs/router.js
@@ -2,6 +2,7 @@ import { createRouter, createWebHashHistory } from "vue-router";
 import ContentIndexPage from "../admin/ContentIndexPage.vue";
 import ContentNewPage from "../admin/ContentNewPage.vue";
 import CategoryEditPage from "../admin/CategoryEditPage.vue";
+import TalkThemeEditPage from "../admin/TalkThemeEditPage.vue";
 
 const routes = [
   { path: "/", 
@@ -10,7 +11,10 @@ const routes = [
     component: ContentNewPage },
   { path: '/categories/:id(\\d+)/edit',
     name: 'CategoryEditPage',
-    component: CategoryEditPage  }
+    component: CategoryEditPage  },
+  { path: '/talk_themes/:id(\\d+)/edit',
+    name: 'TalkThemeEditPage',
+    component: TalkThemeEditPage  },
 ]
 
 const router = createRouter({

--- a/app/serializers/talk_theme_serializer.rb
+++ b/app/serializers/talk_theme_serializer.rb
@@ -1,3 +1,3 @@
 class TalkThemeSerializer < ActiveModel::Serializer
-  attributes :content, :category_id
+  attributes :id, :content, :category_id
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,7 +11,7 @@ Rails.application.routes.draw do
   namespace :api, {format: 'json'} do
     namespace :v1 do
       resources :categories, only: [:index, :create, :show, :update, :destroy]
-      resources :talk_themes, only: [:index, :create]
+      resources :talk_themes, only: [:index, :create, :show, :update]
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,7 +10,7 @@ Rails.application.routes.draw do
   
   namespace :api, {format: 'json'} do
     namespace :v1 do
-      resources :categories, only: [:index, :create, :edit, :update, :destroy]
+      resources :categories, only: [:index, :create, :show, :update, :destroy]
       resources :talk_themes, only: [:index, :create]
     end
   end


### PR DESCRIPTION
## 変更の概要
管理者専用画面にトークテーマ・カテゴリー編集画面を追加する。

## なぜこの変更をするのか
管理者がこのサイト内でトークテーマ・カテゴリーの編集をできるようにするため。

## やったこと
1. admin/CategoryEditPage.vue, admin/TalkThemeEditPage.vueを作成する。
2. vue-routerでルーティングを設定
3. 上記のファイルにトークテーマ・カテゴリーの編集フォームを追加する。
4. axiosを用いて、トークテーマ・カテゴリーの編集内容を保存できるようにする。
5. 管理者トークテーマ一覧画面のトークテーマ・カテゴリーの右横に編集画面へ遷移するためのボタンを付ける。

## 関連issue
- #17 