### PR TITLE
refactor: 管理者専用画面の共通部分をコンポーネントにし、再利用できるようにする。

### DIFF
--- a/app/javascript/admin/CategoryEditPage.vue
+++ b/app/javascript/admin/CategoryEditPage.vue
@@ -1,5 +1,5 @@
 <template>
-  <category-form-pane :category="category" :errors="errors" @submit="updateCategory"></category-form-pane>
+  <category-form-pane :category="category" :errors="errors" @submit="updateCategory">カテゴリーを更新</category-form-pane>
 </template>
 
 <script>

--- a/app/javascript/admin/CategoryEditPage.vue
+++ b/app/javascript/admin/CategoryEditPage.vue
@@ -1,21 +1,15 @@
 <template>
-  <form @submit.prevent="updateCategory">
-    <error-message-display :errors="errors"></error-message-display>
-    <div>
-      <input v-model="category.name" type="text" />
-    </div>
-    <button type="submit">カテゴリーを更新</button>
-  </form>
+  <category-form-pane :category="category" :errors="errors" @submit="updateCategory"></category-form-pane>
 </template>
 
 <script>
 import axios from "axios";
 
-import ErrorMessageDisplay from "./components/ErrorMessageDisplay.vue";
+import CategoryFormPane from "./components/CategoryFormPane.vue";
 
 export default {
   components: {
-    ErrorMessageDisplay,
+    CategoryFormPane,
   },
   data() {
     return {

--- a/app/javascript/admin/CategoryEditPage.vue
+++ b/app/javascript/admin/CategoryEditPage.vue
@@ -1,12 +1,6 @@
 <template>
   <form @submit.prevent="updateCategory">
-    <div v-if="errors.length != 0">
-      <ul v-for="error in errors" :key="error">
-        <li>
-          <font color="red">{{ error }}</font>
-        </li>
-      </ul>
-    </div>
+    <error-message-display :errors="errors"></error-message-display>
     <div>
       <input v-model="category.name" type="text" />
     </div>
@@ -15,36 +9,41 @@
 </template>
 
 <script>
-import axios from 'axios';
+import axios from "axios";
+
+import ErrorMessageDisplay from "./components/ErrorMessageDisplay.vue";
 
 export default {
+  components: {
+    ErrorMessageDisplay,
+  },
   data() {
     return {
       category: {},
-      errors: ''
-    }
+      errors: "",
+    };
   },
-  mounted () {
+  mounted() {
     axios
       .get(`/api/v1/categories/${this.$route.params.id}`)
-      .then(response => (this.category = response.data))
+      .then((response) => (this.category = response.data));
   },
   methods: {
-    updateCategory: function() {
+    updateCategory: function () {
       axios
         .patch(`/api/v1/categories/${this.category.id}`, this.category)
         .then(() => {
           this.$router.push({ path: "/" });
         })
-        .catch(error => {
+        .catch((error) => {
           console.error(error);
           if (error.response.data && error.response.data.errors) {
             this.errors = error.response.data.errors;
           }
         });
-    }
-  }
-}
+    },
+  },
+};
 </script>
 
 <style scoped></style>

--- a/app/javascript/admin/ContentIndexPage.vue
+++ b/app/javascript/admin/ContentIndexPage.vue
@@ -1,12 +1,5 @@
 <template>
   <h2>content</h2>
-  <div v-if="errors.length != 0">
-    <ul v-for="error in errors" :key="error">
-      <li>
-        <font color="red">{{ error }}</font>
-      </li>
-    </ul>
-  </div>
   <div v-for="category in categories" :key="category.id">
     <h3>
       {{ category.name }}
@@ -34,7 +27,6 @@ export default {
   data() {
     return {
       categories: {},
-      errors: "",
     };
   },
   mounted() {
@@ -44,30 +36,14 @@ export default {
   },
   methods: {
     deleteCategory(delete_id) {
-      axios
-        .delete(`/api/v1/categories/${delete_id}`)
-        .then(() => {
-          this.updateContents();
-        })
-        .catch((error) => {
-          console.error(error);
-          if (error.response.data && error.response.data.errors) {
-            this.errors = error.response.data.errors;
-          }
-        });
+      axios.delete(`/api/v1/categories/${delete_id}`).then(() => {
+        this.updateContents();
+      });
     },
     deleteTalkTheme(delete_id) {
-      axios
-        .delete(`/api/v1/talk_themes/${delete_id}`)
-        .then(() => {
-          this.updateContents();
-        })
-        .catch((error) => {
-          console.error(error);
-          if (error.response.data && error.response.data.errors) {
-            this.errors = error.response.data.errors;
-          }
-        });
+      axios.delete(`/api/v1/categories/${delete_id}`).then(() => {
+        this.updateContents();
+      });
     },
     updateContents: function () {
       axios

--- a/app/javascript/admin/ContentNewPage.vue
+++ b/app/javascript/admin/ContentNewPage.vue
@@ -1,6 +1,6 @@
 <template>
-  <talk-theme-form-pane :talk_theme="talk_theme" :categories="categories" :errors="talk_theme.errors" @submit="createTalkTheme"></talk-theme-form-pane>
-  <category-form-pane :category="category" :errors="category.errors" @submit="createCategory"></category-form-pane>
+  <talk-theme-form-pane :talk_theme="talk_theme" :categories="categories" :errors="talk_theme.errors" @submit="createTalkTheme">トークテーマを作成</talk-theme-form-pane>
+  <category-form-pane :category="category" :errors="category.errors" @submit="createCategory">カテゴリーを作成</category-form-pane>
 </template>
 
 <script>

--- a/app/javascript/admin/ContentNewPage.vue
+++ b/app/javascript/admin/ContentNewPage.vue
@@ -1,12 +1,6 @@
 <template>
   <form @submit.prevent="createTalkTheme">
-    <div v-if="talk_theme.errors.length != 0">
-      <ul v-for="error in talk_theme.errors" :key="error">
-        <li>
-          <font color="red">{{ error }}</font>
-        </li>
-      </ul>
-    </div>
+    <error-message-display :errors="talk_theme.errors"></error-message-display>
     <div>
       <input v-model="talk_theme.content" type="text" /> ?
     </div>
@@ -26,13 +20,7 @@
   </form>
 
   <form @submit.prevent="createCategory">
-    <div v-if="category.errors.length != 0">
-      <ul v-for="error in category.errors" :key="error">
-        <li>
-          <font color="red">{{ error }}</font>
-        </li>
-      </ul>
-    </div>
+    <error-message-display :errors="category.errors"></error-message-display>
     <div>
       <input v-model="category.name" type="text" />
     </div>
@@ -43,7 +31,12 @@
 <script>
 import axios from "axios";
 
+import ErrorMessageDisplay from './components/ErrorMessageDisplay.vue';
+
 export default {
+  components: {
+    ErrorMessageDisplay
+  },
   data() {
     return {
       talk_theme: {

--- a/app/javascript/admin/ContentNewPage.vue
+++ b/app/javascript/admin/ContentNewPage.vue
@@ -1,41 +1,18 @@
 <template>
-  <form @submit.prevent="createTalkTheme">
-    <error-message-display :errors="talk_theme.errors"></error-message-display>
-    <div>
-      <input v-model="talk_theme.content" type="text" /> ?
-    </div>
-    <div>
-      <select v-model="talk_theme.category_id">
-        <option disabled value="">選択してください</option>
-        <option
-          v-for="category in categories"
-          :value="category.id"
-          :key="category.id"
-        >
-          {{ category.name }}
-        </option>
-      </select>
-    </div>
-    <button type="submit">トークテーマを作成</button>
-  </form>
-
-  <form @submit.prevent="createCategory">
-    <error-message-display :errors="category.errors"></error-message-display>
-    <div>
-      <input v-model="category.name" type="text" />
-    </div>
-    <button type="submit">カテゴリーを作成</button>
-  </form>
+  <talk-theme-form-pane :talk_theme="talk_theme" :categories="categories" :errors="talk_theme.errors" @submit="createTalkTheme"></talk-theme-form-pane>
+  <category-form-pane :category="category" :errors="category.errors" @submit="createCategory"></category-form-pane>
 </template>
 
 <script>
 import axios from "axios";
 
-import ErrorMessageDisplay from './components/ErrorMessageDisplay.vue';
+import TalkThemeFormPane from "./components/TalkThemeFormPane.vue";
+import CategoryFormPane from "./components/CategoryFormPane.vue";
 
 export default {
   components: {
-    ErrorMessageDisplay
+    TalkThemeFormPane,
+    CategoryFormPane,
   },
   data() {
     return {
@@ -59,13 +36,10 @@ export default {
   methods: {
     createTalkTheme: function () {
       axios
-        .post(
-          "/api/v1/talk_themes",
-          {
-            content: this.talk_theme.content,
-            category_id: this.talk_theme.category_id
-          }
-        )
+        .post("/api/v1/talk_themes", {
+          content: this.talk_theme.content,
+          category_id: this.talk_theme.category_id,
+        })
         .then(() => {
           this.$router.push({ path: "/" });
         })
@@ -78,7 +52,7 @@ export default {
     },
     createCategory: function () {
       axios
-        .post("/api/v1/categories", {name: this.category.name})
+        .post("/api/v1/categories", { name: this.category.name })
         .then(() => {
           this.$router.push({ path: "/" });
         })

--- a/app/javascript/admin/TalkThemeEditPage.vue
+++ b/app/javascript/admin/TalkThemeEditPage.vue
@@ -1,12 +1,6 @@
 <template>
   <form @submit.prevent="updateTalkTheme">
-    <div v-if="errors.length != 0">
-      <ul v-for="error in errors" :key="error">
-        <li>
-          <font color="red">{{ error }}</font>
-        </li>
-      </ul>
-    </div>
+    <error-message-display :errors="errors"></error-message-display>
     <div><input v-model="talk_theme.content" type="text" /> ?</div>
     <div>
       <select v-model="talk_theme.category_id">
@@ -27,7 +21,12 @@
 <script>
 import axios from "axios";
 
+import ErrorMessageDisplay from "./components/ErrorMessageDisplay.vue";
+
 export default {
+  components: {
+    ErrorMessageDisplay,
+  },
   data() {
     return {
       talk_theme: {},

--- a/app/javascript/admin/TalkThemeEditPage.vue
+++ b/app/javascript/admin/TalkThemeEditPage.vue
@@ -1,5 +1,5 @@
 <template>
-  <talk-theme-form-pane :talk_theme="talk_theme" :categories="categories" :errors="errors" @submit="updateTalkTheme"></talk-theme-form-pane>
+  <talk-theme-form-pane :talk_theme="talk_theme" :categories="categories" :errors="errors" @submit="updateTalkTheme">トークテーマを更新</talk-theme-form-pane>
 </template>
 
 <script>

--- a/app/javascript/admin/TalkThemeEditPage.vue
+++ b/app/javascript/admin/TalkThemeEditPage.vue
@@ -1,31 +1,15 @@
 <template>
-  <form @submit.prevent="updateTalkTheme">
-    <error-message-display :errors="errors"></error-message-display>
-    <div><input v-model="talk_theme.content" type="text" /> ?</div>
-    <div>
-      <select v-model="talk_theme.category_id">
-        <option disabled value="">選択してください</option>
-        <option
-          v-for="category in categories"
-          :value="category.id"
-          :key="category.id"
-        >
-          {{ category.name }}
-        </option>
-      </select>
-    </div>
-    <button type="submit">トークテーマを更新</button>
-  </form>
+  <talk-theme-form-pane :talk_theme="talk_theme" :categories="categories" :errors="errors" @submit="updateTalkTheme"></talk-theme-form-pane>
 </template>
 
 <script>
 import axios from "axios";
 
-import ErrorMessageDisplay from "./components/ErrorMessageDisplay.vue";
+import TalkThemeFormPane from "./components/TalkThemeFormPane.vue";
 
 export default {
   components: {
-    ErrorMessageDisplay,
+    TalkThemeFormPane,
   },
   data() {
     return {

--- a/app/javascript/admin/components/CategoryFormPane.vue
+++ b/app/javascript/admin/components/CategoryFormPane.vue
@@ -4,7 +4,7 @@
     <div>
       <input v-model="category.name" type="text" />
     </div>
-    <button type="submit">カテゴリーを作成</button>
+    <button type="submit"><slot></slot></button>
   </form>
 </template>
 

--- a/app/javascript/admin/components/CategoryFormPane.vue
+++ b/app/javascript/admin/components/CategoryFormPane.vue
@@ -1,0 +1,31 @@
+<template>
+  <form @submit.prevent="onSubmit()">
+    <error-message-display :errors="errors"></error-message-display>
+    <div>
+      <input v-model="category.name" type="text" />
+    </div>
+    <button type="submit">カテゴリーを作成</button>
+  </form>
+</template>
+
+<script>
+import ErrorMessageDisplay from "./ErrorMessageDisplay.vue";
+
+export default {
+  components: {
+    ErrorMessageDisplay,
+  },
+  props: {
+    category: {},
+    errors: "",
+  },
+  emits: ["submit"],
+  methods: {
+    onSubmit() {
+      this.$emit("submit");
+    },
+  },
+};
+</script>
+
+<style scoped></style>

--- a/app/javascript/admin/components/ErrorMessageDisplay.vue
+++ b/app/javascript/admin/components/ErrorMessageDisplay.vue
@@ -1,0 +1,19 @@
+<template>
+  <div v-if="errors.length != 0">
+    <ul v-for="error in errors" :key="error">
+      <li>
+        <font color="red">{{ error }}</font>
+      </li>
+    </ul>
+  </div>
+</template>
+
+<script>
+export default {
+  props: {
+    errors: ""
+  }
+}
+</script>
+
+<style scoped></style>

--- a/app/javascript/admin/components/TalkThemeFormPane.vue
+++ b/app/javascript/admin/components/TalkThemeFormPane.vue
@@ -1,0 +1,42 @@
+<template>
+  <form @submit.prevent="onSubmit()">
+    <error-message-display :errors="errors"></error-message-display>
+    <div><input v-model="talk_theme.content" type="text" /> ?</div>
+    <div>
+      <select v-model="talk_theme.category_id">
+        <option disabled value="">選択してください</option>
+        <option
+          v-for="category in categories"
+          :value="category.id"
+          :key="category.id"
+        >
+          {{ category.name }}
+        </option>
+      </select>
+    </div>
+    <button type="submit">トークテーマを作成</button>
+  </form>
+</template>
+
+<script>
+import ErrorMessageDisplay from "./ErrorMessageDisplay.vue";
+
+export default {
+  components: {
+    ErrorMessageDisplay,
+  },
+  props: {
+    talk_theme: {},
+    categories: {},
+    errors: "",
+  },
+  emits: ["submit"],
+  methods: {
+    onSubmit() {
+      this.$emit("submit");
+    },
+  },
+};
+</script>
+
+<style scoped></style>

--- a/app/javascript/admin/components/TalkThemeFormPane.vue
+++ b/app/javascript/admin/components/TalkThemeFormPane.vue
@@ -14,7 +14,7 @@
         </option>
       </select>
     </div>
-    <button type="submit">トークテーマを作成</button>
+    <button type="submit"><slot></slot></button>
   </form>
 </template>
 


### PR DESCRIPTION
## 変更の概要
管理者専用画面の共通部分をコンポーネントにし、再利用できるようにする。

## なぜこの変更をするのか
共通部分をコンポーネントにすることで、共通部分に変更がある場合、そのコンポーネントのみの編集で済ませることができるため。

## やったこと
1. エラーメッセージの表示部分をコンポーネントにする。
2. カテゴリーの新規登録・編集フォームをコンポーネントにする。
3. トークテーマの新規登録・編集フォームをコンポーネントにする。

## 関連issue
- #20 