### PR TITLE
feat: エンドユーザー側のトークテーマ・カテゴリー一覧画面でトークテーマにいいねをできるようにする。

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,3 +58,4 @@ gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 gem 'devise'
 gem 'seed-fu'
 gem "active_model_serializers"
+gem "net-smtp"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -93,6 +93,7 @@ GEM
       railties (>= 4.1.0)
       responders
       warden (~> 1.2.3)
+    digest (3.1.0)
     erubi (1.11.0)
     ffi (1.15.5)
     globalid (1.0.0)
@@ -117,6 +118,12 @@ GEM
     mini_mime (1.1.2)
     minitest (5.16.3)
     msgpack (1.5.6)
+    net-protocol (0.1.3)
+      timeout
+    net-smtp (0.3.1)
+      digest
+      net-protocol
+      timeout
     nio4r (2.5.8)
     nokogiri (1.13.8-x86_64-linux)
       racc (~> 1.4)
@@ -198,6 +205,7 @@ GEM
     sqlite3 (1.5.0-x86_64-linux)
     thor (1.2.1)
     tilt (2.0.11)
+    timeout (0.3.0)
     turbolinks (5.2.1)
       turbolinks-source (~> 5.2)
     turbolinks-source (5.2.0)
@@ -238,6 +246,7 @@ DEPENDENCIES
   devise
   jbuilder (~> 2.7)
   listen (~> 3.3)
+  net-smtp
   puma (~> 5.0)
   rack-mini-profiler (~> 2.0)
   rails (~> 6.1.7)

--- a/app/controllers/api/v1/categories_controller.rb
+++ b/app/controllers/api/v1/categories_controller.rb
@@ -8,8 +8,8 @@ class Api::V1::CategoriesController < ApiController
   end
 
   def index
-    categories = Category.preload(:talk_themes).all
-    render json: categories, each_serializer: CategorySerializer, include: [ :talk_themes ]
+    categories = Category.includes(talk_themes: :likes).all
+    render json: categories, each_serializer: CategorySerializer, include: [talk_themes: :likes]
   end
 
   def show
@@ -19,7 +19,7 @@ class Api::V1::CategoriesController < ApiController
   def create
     category =  Category.new(category_params)
     if category.save
-      render json:  category, status: :created
+      head :created
     else
       render json: { errors:  category.errors.full_messages }, status: :unprocessable_entity
     end

--- a/app/controllers/api/v1/likes_controller.rb
+++ b/app/controllers/api/v1/likes_controller.rb
@@ -1,0 +1,13 @@
+class Api::V1::LikesController < ApiController
+
+  # ActiveRecordのレコードが見つからなければ404 not foundを応答する
+  rescue_from ActiveRecord::RecordNotFound do |exception|
+    render json: { error: '404 not found' }, status: 404
+  end
+
+  def create
+  end
+
+  def destory
+  end
+end

--- a/app/controllers/api/v1/likes_controller.rb
+++ b/app/controllers/api/v1/likes_controller.rb
@@ -1,13 +1,34 @@
 class Api::V1::LikesController < ApiController
+  before_action :set_like, only: [:judge, :destroy]
 
   # ActiveRecordのレコードが見つからなければ404 not foundを応答する
   rescue_from ActiveRecord::RecordNotFound do |exception|
     render json: { error: '404 not found' }, status: 404
   end
 
-  def create
+  def show
+    likes = Like.where(talk_theme_id: params[:talk_theme_id])
+    render json: likes, each_serializer: LikeSerializer
   end
 
-  def destory
+  def judge
+    render json: @like
+  end
+
+  def create
+    like = Like.create(ip: request.remote_ip, talk_theme_id: params[:talk_theme_id])
+    like.save
+    head :created
+  end
+
+  def destroy
+    @like.destroy
+    head :no_content
+  end
+
+  private
+
+  def set_like
+    @like = Like.find_by(ip: request.remote_ip, talk_theme_id: params[:talk_theme_id])
   end
 end

--- a/app/controllers/api/v1/talk_themes_controller.rb
+++ b/app/controllers/api/v1/talk_themes_controller.rb
@@ -8,7 +8,7 @@ class Api::V1::TalkThemesController < ApiController
   end
 
   def index
-    talk_themes = TalkTheme.all
+    talk_themes = TalkTheme.includes(:likes).all
     render json: talk_themes, each_serializer: TalkThemeSerializer
   end
 
@@ -19,7 +19,7 @@ class Api::V1::TalkThemesController < ApiController
   def create
     talk_theme =  TalkTheme.new(talk_theme_params)
     if talk_theme.save
-      render json:  talk_theme, status: :created
+      head :created
     else
       render json: { errors:  talk_theme.errors.full_messages }, status: :unprocessable_entity
     end

--- a/app/helpers/admin/api/v1/categories_helper.rb
+++ b/app/helpers/admin/api/v1/categories_helper.rb
@@ -1,2 +1,0 @@
-module Admin::Api::V1::CategoriesHelper
-end

--- a/app/helpers/api/v1/categories_helper.rb
+++ b/app/helpers/api/v1/categories_helper.rb
@@ -1,0 +1,2 @@
+module Api::V1::CategoriesHelper
+end

--- a/app/helpers/api/v1/likes_helper.rb
+++ b/app/helpers/api/v1/likes_helper.rb
@@ -1,0 +1,2 @@
+module Api::V1::LikesHelper
+end

--- a/app/helpers/api/v1/talk_themes_helper.rb
+++ b/app/helpers/api/v1/talk_themes_helper.rb
@@ -1,0 +1,2 @@
+module Api::V1::TalkThemesHelper
+end

--- a/app/javascript/admin/ContentIndexPage.vue
+++ b/app/javascript/admin/ContentIndexPage.vue
@@ -15,8 +15,14 @@
             >
           </div>
         </div>
-        <div class="row dropdown" v-for="category in categories" :key="category.id">
-          <dl class="col-sm-11 col-10 d-flex flex-wrap bg-dark text-white p-2 m-0">
+        <div
+          class="row dropdown"
+          v-for="category in sortedTalkThemesByLikes"
+          :key="category.id"
+        >
+          <dl
+            class="col-sm-11 col-10 d-flex flex-wrap bg-dark text-white p-2 m-0"
+          >
             <dt class="w-25 me-3">{{ category.name }}</dt>
             <dd class="me-auto">
               <router-link
@@ -48,11 +54,11 @@
               :key="talk_theme.id"
               v-if="category.talk_themes.length != 0"
             >
-              <dl class="d-inline-flex flex-wrap m-0">
-                <dt class="w-75 mb-2 text-wrap">
+              <div class="row d-inline-flex flex-wrap m-0">
+                <div class="col-12 col-sm-6 mb-2 text-wrap">
                   {{ talk_theme.content }} ?
-                </dt>
-                <dd>
+                </div>
+                <div class="col-12 col-sm-6">
                   <router-link
                     class="btn btn-success me-2"
                     :to="{
@@ -62,12 +68,13 @@
                     >編集</router-link
                   >
                   <a
-                    class="btn btn-danger"
+                    class="btn btn-danger me-2"
                     @click="deleteTalkTheme(talk_theme.id)"
                     >削除</a
                   >
-                </dd>
-              </dl>
+                  <span> いいね数: {{ talk_theme.likes.length }} </span>
+                </div>
+              </div>
             </li>
             <li class="d-block px-1 py-2" v-else>
               <dl class="m-0">
@@ -95,17 +102,29 @@ export default {
   },
   data() {
     return {
-      categories: {},
-      talk_themes: {},
+      categories: [],
+      talk_themes: [],
     };
   },
-  mounted() {
+  created() {
     axios
       .get("/api/v1/categories")
       .then((response) => (this.categories = response.data));
     axios
       .get("/api/v1/talk_themes")
       .then((response) => (this.talk_themes = response.data));
+  },
+  computed: {
+    sortedTalkThemesByLikes() {
+      const talk_themes_sorted = [];
+      this.categories.forEach((category) => {
+        talk_themes_sorted.push(category);
+        return category.talk_themes.sort((a, b) => {
+          return b.likes.length - a.likes.length;
+        });
+      });
+      return talk_themes_sorted
+    },
   },
   methods: {
     deleteCategory(delete_id) {

--- a/app/javascript/components/TalkThemeLikeButton.vue
+++ b/app/javascript/components/TalkThemeLikeButton.vue
@@ -1,7 +1,13 @@
 <template>
   <dd>
-    <div v-if="isLiked" @click="deleteLike()">いいねを取り消す {{ count }}</div>
-    <div v-else @click="createLike()">いいねする {{ count }}</div>
+    <div class="" v-if="isLiked" @click="deleteLike()">
+      <i class="fa-solid fa-heart create-heart me-2"></i>
+      <span>{{ count }}</span>
+    </div>
+    <div class="heart-size" v-else @click="createLike()">
+      <i class="fa-regular fa-heart destroy-heart me-2"></i>
+      <span>{{ count }}</span>
+    </div>
   </dd>
 </template>
 
@@ -68,4 +74,15 @@ export default {
 };
 </script>
 
-<style scoped></style>
+<style scoped>
+.fa-heart {
+    font-size: 1.7rem
+  }
+.create-heart {
+  color: #DE3F4E
+}
+
+.destroy-heart {
+  color: #707070
+}
+</style>

--- a/app/javascript/components/TalkThemeLikeButton.vue
+++ b/app/javascript/components/TalkThemeLikeButton.vue
@@ -1,0 +1,71 @@
+<template>
+  <dd>
+    <div v-if="isLiked" @click="deleteLike()">いいねを取り消す {{ count }}</div>
+    <div v-else @click="createLike()">いいねする {{ count }}</div>
+  </dd>
+</template>
+
+<script>
+import axios from "axios";
+
+export default {
+  props: {
+    talk_theme_id: "",
+    likes: {},
+  },
+  data() {
+    return {
+      isLiked: "",
+      date_likes: {},
+      likes_count: "",
+    };
+  },
+  created() {
+    this.likes_count = this.likes.length;
+    this.findLikeByIpAddress();
+  },
+  computed: {
+    count() {
+      return this.likes_count;
+    },
+    isLike() {
+      return Boolean(this.isLiked);
+    },
+  },
+  methods: {
+    createLike: function () {
+      axios
+        .post(`/api/v1/talk_themes/${this.talk_theme_id}/like`, {
+          talk_theme_id: this.talk_theme_id,
+        })
+        .then(() => {
+          this.fetchLikeByTalkThemeId();
+          this.findLikeByIpAddress();
+        });
+    },
+    deleteLike: function () {
+      axios
+        .delete(`/api/v1/talk_themes/${this.talk_theme_id}/like`)
+        .then(() => {
+          this.fetchLikeByTalkThemeId();
+          this.findLikeByIpAddress();
+        });
+    },
+    fetchLikeByTalkThemeId: function () {
+      axios
+        .get(`/api/v1/talk_themes/${this.talk_theme_id}/like`)
+        .then((response) => {
+          this.date_likes = response.data;
+          this.likes_count = this.date_likes.length;
+        });
+    },
+    findLikeByIpAddress: function () {
+      axios
+        .get(`/api/v1/talk_themes/${this.talk_theme_id}/like/judge`)
+        .then((response) => (this.isLiked = response.data));
+    },
+  },
+};
+</script>
+
+<style scoped></style>

--- a/app/javascript/end_user/ContentIndexPage.vue
+++ b/app/javascript/end_user/ContentIndexPage.vue
@@ -25,12 +25,14 @@
               :key="talk_theme.id"
               v-if="category.talk_themes.length != 0"
             >
-              <dl class="d-inline-flex flex-wrap m-0">
-                <dt class="mb-2 text-wrap">{{ talk_theme.content }} ?</dt>
-                <talk-theme-like-button
-                  :talk_theme_id="talk_theme.id"
-                  :likes="talk_theme.likes"
-                ></talk-theme-like-button>
+              <dl class="row d-inline-flex flex-wrap m-0">
+                <dt class="col-12 col-sm-11 text-wrap">{{ talk_theme.content }} ?</dt>
+                <dd class="col-1">
+                  <talk-theme-like-button
+                    :talk_theme_id="talk_theme.id"
+                    :likes="talk_theme.likes"
+                  ></talk-theme-like-button>
+                </dd>
               </dl>
             </li>
             <li class="d-block px-1 py-2" v-else>

--- a/app/javascript/end_user/ContentIndexPage.vue
+++ b/app/javascript/end_user/ContentIndexPage.vue
@@ -27,6 +27,10 @@
             >
               <dl class="d-inline-flex flex-wrap m-0">
                 <dt class="mb-2 text-wrap">{{ talk_theme.content }} ?</dt>
+                <talk-theme-like-button
+                  :talk_theme_id="talk_theme.id"
+                  :likes="talk_theme.likes"
+                ></talk-theme-like-button>
               </dl>
             </li>
             <li class="d-block px-1 py-2" v-else>
@@ -46,11 +50,13 @@
 import axios from "axios";
 
 import Header from "../components/Header.vue";
+import TalkThemeLikeButton from "../components/TalkThemeLikeButton.vue";
 import Footer from "../components/Footer.vue";
 
 export default {
   components: {
     Header,
+    TalkThemeLikeButton,
     Footer,
   },
   data() {
@@ -59,21 +65,24 @@ export default {
       talk_themes: {},
     };
   },
-  mounted() {
-    axios
-      .get("/api/v1/categories")
-      .then((response) => (this.categories = response.data));
+  created() {
+    this.fetchCategories();
     axios
       .get("/api/v1/talk_themes")
       .then((response) => (this.talk_themes = response.data));
   },
   methods: {
+    fetchCategories: function () {
+      axios.get("/api/v1/categories").then((response) => {
+        this.categories = response.data;
+      });
+    },
     deleteCategory(delete_id) {
       if (
         confirm(`「${this.categoryName(delete_id)}」を削除してよろしいですか?`)
       )
         axios.delete(`/api/v1/categories/${delete_id}`).then(() => {
-          this.updateContents();
+          this.fetchCategories();
         });
     },
     deleteTalkTheme(delete_id) {
@@ -83,7 +92,7 @@ export default {
         )
       )
         axios.delete(`/api/v1/talk_themes/${delete_id}`).then(() => {
-          this.updateContents();
+          this.fetchCategories();
         });
     },
     categoryName(delete_id) {
@@ -97,11 +106,6 @@ export default {
         (talk_theme) => talk_theme.id === delete_id
       );
       return filterDate[0].content;
-    },
-    updateContents: function () {
-      axios
-        .get("/api/v1/categories")
-        .then((response) => (this.categories = response.data));
     },
   },
 };

--- a/app/javascript/end_user/ContentIndexPage.vue
+++ b/app/javascript/end_user/ContentIndexPage.vue
@@ -73,9 +73,23 @@ export default {
   },
   methods: {
     fetchCategories: function () {
-      axios.get("/api/v1/categories").then((response) => {
-        this.categories = response.data;
+      axios
+        .get("/api/v1/categories")
+        .then((response) => {
+          this.categories = response.data;
+        })
+        .then(() => (this.categories = this.sortedTalkThemesByLikes()));
+    },
+    sortedTalkThemesByLikes: function () {
+      const talk_themes_sorted = [];
+      console.log(this.categories);
+      this.categories.forEach((category) => {
+        talk_themes_sorted.push(category);
+        return category.talk_themes.sort((a, b) => {
+          return b.likes.length - a.likes.length;
+        });
       });
+      return talk_themes_sorted;
     },
     deleteCategory(delete_id) {
       if (

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -9,6 +9,7 @@ import * as ActiveStorage from "@rails/activestorage"
 import "channels"
 import "bootstrap";
 import "../stylesheets/application.scss";
+import "@fortawesome/fontawesome-free/js/all";
 
 Rails.start()
 Turbolinks.start()

--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -1,1 +1,2 @@
 @import "~bootstrap/scss/bootstrap.scss";
+@import '@fortawesome/fontawesome-free/scss/fontawesome';

--- a/app/models/like.rb
+++ b/app/models/like.rb
@@ -1,0 +1,3 @@
+class Like < ApplicationRecord
+  belongs_to :talk_theme
+end

--- a/app/models/talk_theme.rb
+++ b/app/models/talk_theme.rb
@@ -1,4 +1,5 @@
 class TalkTheme < ApplicationRecord
   belongs_to :category
+  has_many :likes, dependent: :destroy
   validates :content, presence: true
 end

--- a/app/serializers/category_serializer.rb
+++ b/app/serializers/category_serializer.rb
@@ -1,5 +1,5 @@
 class CategorySerializer < ActiveModel::Serializer
   attributes :id, :name
 
-  has_many :talk_themes
+  has_many :talk_themes, serializer: TalkThemeSerializer
 end

--- a/app/serializers/like_serializer.rb
+++ b/app/serializers/like_serializer.rb
@@ -1,0 +1,3 @@
+class LikeSerializer < ActiveModel::Serializer
+  attributes :id, :talk_theme_id, :ip
+end

--- a/app/serializers/talk_theme_serializer.rb
+++ b/app/serializers/talk_theme_serializer.rb
@@ -1,3 +1,5 @@
 class TalkThemeSerializer < ActiveModel::Serializer
   attributes :id, :content, :category_id
+
+  has_many :likes, serializer: LikeSerializer
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,7 +15,11 @@ Rails.application.routes.draw do
     namespace :v1 do
       resources :categories, only: [:index, :create, :show, :update, :destroy]
       resources :talk_themes, only: [:index, :create, :show, :update, :destroy] do
-        resource :like, only: [:create, :destroy]
+        resource :like, only: [:show, :create, :destroy] do
+          collection do
+            get 'judge'
+          end
+        end
       end
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,7 +14,9 @@ Rails.application.routes.draw do
   namespace :api, {format: 'json'} do
     namespace :v1 do
       resources :categories, only: [:index, :create, :show, :update, :destroy]
-      resources :talk_themes, only: [:index, :create, :show, :update, :destroy]
+      resources :talk_themes, only: [:index, :create, :show, :update, :destroy] do
+        resource :like, only: [:create, :destroy]
+      end
     end
   end
 end

--- a/db/migrate/20221023112559_create_likes.rb
+++ b/db/migrate/20221023112559_create_likes.rb
@@ -1,0 +1,10 @@
+class CreateLikes < ActiveRecord::Migration[6.1]
+  def change
+    create_table :likes do |t|
+      t.references :talk_theme, null: false, foreign_key: true
+      t.string :ip 
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_10_05_025906) do
+ActiveRecord::Schema.define(version: 2022_10_23_112559) do
 
   create_table "admins", force: :cascade do |t|
     t.string "email", default: "", null: false
@@ -30,6 +30,14 @@ ActiveRecord::Schema.define(version: 2022_10_05_025906) do
     t.datetime "updated_at", precision: 6, null: false
   end
 
+  create_table "likes", force: :cascade do |t|
+    t.integer "talk_theme_id", null: false
+    t.string "ip"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["talk_theme_id"], name: "index_likes_on_talk_theme_id"
+  end
+
   create_table "talk_themes", force: :cascade do |t|
     t.string "content", null: false
     t.integer "category_id", null: false
@@ -38,5 +46,6 @@ ActiveRecord::Schema.define(version: 2022_10_05_025906) do
     t.index ["category_id"], name: "index_talk_themes_on_category_id"
   end
 
+  add_foreign_key "likes", "talk_themes"
   add_foreign_key "talk_themes", "categories"
 end

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "bilbil",
   "private": true,
   "dependencies": {
+    "@fortawesome/fontawesome-free": "^6.2.0",
     "@popperjs/core": "^2.11.6",
     "@rails/actioncable": "^6.0.0",
     "@rails/activestorage": "^6.0.0",

--- a/test/controllers/api/v1/likes_controller_test.rb
+++ b/test/controllers/api/v1/likes_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class Api::V1::LikesControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/fixtures/likes.yml
+++ b/test/fixtures/likes.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/models/like_test.rb
+++ b/test/models/like_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class LikeTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/yarn.lock
+++ b/yarn.lock
@@ -925,6 +925,11 @@
   resolved "https://registry.yarnpkg.com/@csstools/convert-colors/-/convert-colors-1.4.0.tgz#ad495dc41b12e75d588c6db8b9834f08fa131eb7"
   integrity sha512-5a6wqoJV/xEdbRNKVo6I4hO3VjyDq//8q2f9I6PBAvMesJHFauXDorcNCsr9RzvsZnaWi5NYCcfyqP1QeFHFbw==
 
+"@fortawesome/fontawesome-free@^6.2.0":
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-free/-/fontawesome-free-6.2.0.tgz#ba3510825b332816fe7190f28827f8cb33a298b5"
+  integrity sha512-CNR7qRIfCwWHNN7FnKUniva94edPdyQzil/zCwk3v6k4R6rR2Fr8i4s3PM7n/lyfPA6Zfko9z5WDzFxG9SW1uQ==
+
 "@gar/promisify@^1.0.1":
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/@gar/promisify/-/promisify-1.1.3.tgz#555193ab2e3bb3b6adc3d551c9c030d9e860daf6"


### PR DESCRIPTION
## 変更の概要
エンドユーザー側のトークテーマ・カテゴリー一覧画面でトークテーマにいいねをできるようにする。

## なぜこの変更をするのか
どのトークテーマに人気があるのかを数値で分かるようにするため。

## やったこと
1. いいね機能に関するモデル・コントローラを作成する。
2. トークテーマとのアソシエーションを設定する。
3. いいね機能に関するルーティングを設定する。
4. いいねボタンのコンポーネントを作成する。
5. fontawesomeを導入し、いいねボタンをハートアイコンにする。
6. 作成したいいねボタンのコンポーネントをエンドユーザー側のトークテーマ・カテゴリー一覧画面に導入する。
7. 管理者側のトークテーマ・カテゴリー一覧画面でトークテーマのいいね数を表示する。

## 関連issue
- #29 