### PR TITLE
feat: エンドユーザー側のトークテーマ・カテゴリー一覧画面でいいねしたトークテーマを確認しやすくする。

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,6 +42,8 @@ group :development do
   gem 'listen', '~> 3.3'
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'
+  
+  gem 'pry-byebug'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -85,6 +85,7 @@ GEM
     case_transform (0.2)
       activesupport
     childprocess (4.1.0)
+    coderay (1.1.3)
     concurrent-ruby (1.1.10)
     crass (1.0.6)
     devise (4.8.1)
@@ -128,6 +129,12 @@ GEM
     nokogiri (1.13.8-x86_64-linux)
       racc (~> 1.4)
     orm_adapter (0.5.0)
+    pry (0.14.1)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    pry-byebug (3.8.0)
+      byebug (~> 11.0)
+      pry (~> 0.10)
     public_suffix (5.0.0)
     puma (5.6.5)
       nio4r (~> 2.0)
@@ -247,6 +254,7 @@ DEPENDENCIES
   jbuilder (~> 2.7)
   listen (~> 3.3)
   net-smtp
+  pry-byebug
   puma (~> 5.0)
   rack-mini-profiler (~> 2.0)
   rails (~> 6.1.7)

--- a/app/controllers/api/v1/likes_controller.rb
+++ b/app/controllers/api/v1/likes_controller.rb
@@ -15,6 +15,11 @@ class Api::V1::LikesController < ApiController
     render json: @like
   end
 
+  def ip
+    likes = Like.where(ip: request.remote_ip)
+    render json: likes, each_serializer: LikeSerializer
+  end
+
   def create
     like = Like.create(ip: request.remote_ip, talk_theme_id: params[:talk_theme_id])
     like.save

--- a/app/javascript/admin/ContentIndexPage.vue
+++ b/app/javascript/admin/ContentIndexPage.vue
@@ -118,10 +118,10 @@ export default {
     sortedTalkThemesByLikes() {
       const talk_themes_sorted = [];
       this.categories.forEach((category) => {
-        talk_themes_sorted.push(category);
-        return category.talk_themes.sort((a, b) => {
-          return b.likes.length - a.likes.length;
+        category.talk_themes.sort((a, b) => {
+          b.likes.length - a.likes.length;
         });
+        talk_themes_sorted.push(category);
       });
       return talk_themes_sorted
     },

--- a/app/javascript/components/TalkThemeLikeButton.vue
+++ b/app/javascript/components/TalkThemeLikeButton.vue
@@ -19,6 +19,7 @@ export default {
     talk_theme_id: "",
     likes: {},
   },
+  emits: ["fetchCategories", "addBorderToTheLastLike"],
   data() {
     return {
       isLiked: "",
@@ -47,6 +48,8 @@ export default {
         .then(() => {
           this.fetchLikeByTalkThemeId();
           this.findLikeByIpAddress();
+          this.$emit("fetchCategories");
+          this.$emit("addBorderToTheLastLike");
         });
     },
     deleteLike: function () {
@@ -55,6 +58,8 @@ export default {
         .then(() => {
           this.fetchLikeByTalkThemeId();
           this.findLikeByIpAddress();
+          this.$emit("fetchCategories");
+          this.$emit("addBorderToTheLastLike");
         });
     },
     fetchLikeByTalkThemeId: function () {
@@ -76,13 +81,13 @@ export default {
 
 <style scoped>
 .fa-heart {
-    font-size: 1.7rem
-  }
+  font-size: 1.7rem;
+}
 .create-heart {
-  color: #DE3F4E
+  color: #de3f4e;
 }
 
 .destroy-heart {
-  color: #707070
+  color: #707070;
 }
 </style>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,6 +21,7 @@ Rails.application.routes.draw do
           end
         end
       end
+      get 'like/ip' => 'likes#ip'
     end
   end
 end


### PR DESCRIPTION
## 変更の概要
エンドユーザー側のトークテーマ・カテゴリー一覧画面でいいねしたトークテーマを確認しやすくする。

## なぜこの変更をするのか
どのトークテーマにいいねを付けたのかを分かりやすくするため。

## やったこと
1.  いいねをしたトークテーマをトークテーマ一覧の上部に表示するようにする。
2.  いいねをしたトークテーマといいねをしていないトークテーマの間に線を引く。

## 関連issue
- #32 