### PR TITLE
feat: 会話サポートルーレット画面にトークテーマルーレットを作成する。

### DIFF
--- a/app/javascript/admin/CategoryEditPage.vue
+++ b/app/javascript/admin/CategoryEditPage.vue
@@ -9,7 +9,7 @@
           @submit="updateCategory"
           >カテゴリーを更新</category-form-pane
         >
-        <content-index-button></content-index-button>
+        <root-path-button>コンテンツ一覧に戻る</root-path-button>
       </div>
     </div>
   </div>
@@ -21,14 +21,14 @@ import axios from "axios";
 
 import Header from "../components/Header.vue";
 import CategoryFormPane from "../components/CategoryFormPane.vue";
-import ContentIndexButton from "../components/ContentIndexButton.vue";
+import RootPathButton from "../components/RootPathButton.vue";
 import Footer from "../components/Footer.vue";
 
 export default {
   components: {
     Header,
     CategoryFormPane,
-    ContentIndexButton,
+    RootPathButton,
     Footer,
   },
   data() {

--- a/app/javascript/admin/ContentNewPage.vue
+++ b/app/javascript/admin/ContentNewPage.vue
@@ -19,7 +19,7 @@
           @submit="createCategory"
           >カテゴリーを作成</category-form-pane
         >
-        <content-index-button></content-index-button>
+        <root-path-button>コンテンツ一覧に戻る</root-path-button>
       </div>
     </div>
   </div>
@@ -33,7 +33,7 @@ import Header from "../components/Header.vue";
 import Headline from "../components/Headline.vue";
 import TalkThemeFormPane from "../components/TalkThemeFormPane.vue";
 import CategoryFormPane from "../components/CategoryFormPane.vue";
-import ContentIndexButton from "../components/ContentIndexButton.vue";
+import RootPathButton from "../components/RootPathButton.vue";
 import Footer from "../components/Footer.vue";
 
 export default {
@@ -42,7 +42,7 @@ export default {
     Headline,
     TalkThemeFormPane,
     CategoryFormPane,
-    ContentIndexButton,
+    RootPathButton,
     Footer,
   },
   data() {

--- a/app/javascript/admin/TalkThemeEditPage.vue
+++ b/app/javascript/admin/TalkThemeEditPage.vue
@@ -10,7 +10,7 @@
           @submit="updateTalkTheme"
           >トークテーマを更新</talk-theme-form-pane
         >
-        <content-index-button></content-index-button>
+        <root-path-button>コンテンツ一覧に戻る</root-path-button>
       </div>
     </div>
   </div>
@@ -22,14 +22,14 @@ import axios from "axios";
 
 import Header from "../components/Header.vue";
 import TalkThemeFormPane from "../components/TalkThemeFormPane.vue";
-import ContentIndexButton from "../components/ContentIndexButton.vue";
+import RootPathButton from "../components/RootPathButton.vue";
 import Footer from "../components/Footer.vue";
 
 export default {
   components: {
     Header,
     TalkThemeFormPane,
-    ContentIndexButton,
+    RootPathButton,
     Footer,
   },
   data() {

--- a/app/javascript/components/Headline.vue
+++ b/app/javascript/components/Headline.vue
@@ -10,6 +10,6 @@
 
 <style scoped>
   h3 {
-    width: 200px;
+    width: 250px;
   }
 </style>

--- a/app/javascript/components/RootPathButton.vue
+++ b/app/javascript/components/RootPathButton.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="text-center">
     <router-link class="btn btn-dark" to="/"
-      >コンテンツ一覧に戻る</router-link
+      ><slot></slot></router-link
     >
   </div>
 </template>

--- a/app/javascript/end_user/ContentIndexPage.vue
+++ b/app/javascript/end_user/ContentIndexPage.vue
@@ -3,49 +3,52 @@
   <main class="container">
     <div class="row my-5">
       <div class="col-lg-6 mx-auto">
-        <div
-          class="row dropdown"
-          v-for="category in categories"
-          :key="category.id"
-        >
-          <button
-            type="button"
-            class="btn btn-dark dropdown-toggle py-2"
-            data-bs-toggle="dropdown"
-            data-bs-auto-close="false"
+        <root-path-button>トップページに戻る</root-path-button>
+        <div class="mt-5">
+          <div
+            class="row dropdown"
+            v-for="category in categories"
+            :key="category.id"
           >
-            <div class="d-inline-block col-11 text-start">
-              {{ category.name }}
-            </div>
-          </button>
-          <ol class="dropdown-menu p-0">
-            <li
-              v-for="(talk_theme, index) in category.talk_themes"
-              :key="talk_theme.id"
-              v-if="category.talk_themes.length != 0"
-              class="dropdown-item"
-              :class="[index + 1 == this.ip_count ? 'boundary_line' : '']"
+            <button
+              type="button"
+              class="btn btn-dark dropdown-toggle py-2"
+              data-bs-toggle="dropdown"
+              data-bs-auto-close="false"
             >
-              <dl class="row d-inline-flex flex-wrap m-0">
-                <dt class="col-12 col-sm-11 text-wrap">
-                  {{ talk_theme.content }} ?
-                </dt>
-                <dd class="col-1">
-                  <talk-theme-like-button
-                    :talk_theme_id="talk_theme.id"
-                    :likes="talk_theme.likes"
-                    @fetchCategories="fetchCategories"
-                    @addBorderToTheLastLike="addBorderToTheLastLike"
-                  ></talk-theme-like-button>
-                </dd>
-              </dl>
-            </li>
-            <li class="d-block px-1 py-2" v-else>
-              <dl class="m-0">
-                <dt>トークテーマはありません。</dt>
-              </dl>
-            </li>
-          </ol>
+              <div class="d-inline-block col-11 text-start">
+                {{ category.name }}
+              </div>
+            </button>
+            <ol class="dropdown-menu p-0">
+              <li
+                v-for="(talk_theme, index) in category.talk_themes"
+                :key="talk_theme.id"
+                v-if="category.talk_themes.length != 0"
+                class="dropdown-item"
+                :class="[index + 1 == this.ip_count ? 'boundary_line' : '']"
+              >
+                <dl class="row d-inline-flex flex-wrap m-0">
+                  <dt class="col-12 col-sm-11 text-wrap">
+                    {{ talk_theme.content }} ?
+                  </dt>
+                  <dd class="col-1">
+                    <talk-theme-like-button
+                      :talk_theme_id="talk_theme.id"
+                      :likes="talk_theme.likes"
+                      @fetchCategories="fetchCategories"
+                      @addBorderToTheLastLike="addBorderToTheLastLike"
+                    ></talk-theme-like-button>
+                  </dd>
+                </dl>
+              </li>
+              <li class="d-block px-1 py-2" v-else>
+                <dl class="m-0">
+                  <dt>トークテーマはありません。</dt>
+                </dl>
+              </li>
+            </ol>
+          </div>
         </div>
       </div>
     </div>
@@ -58,12 +61,14 @@ import axios from "axios";
 
 import Header from "../components/Header.vue";
 import TalkThemeLikeButton from "../components/TalkThemeLikeButton.vue";
+import RootPathButton from "../components/RootPathButton.vue";
 import Footer from "../components/Footer.vue";
 
 export default {
   components: {
     Header,
     TalkThemeLikeButton,
+    RootPathButton,
     Footer,
   },
   data() {

--- a/app/javascript/end_user/TalkThemeRoulettePage.vue
+++ b/app/javascript/end_user/TalkThemeRoulettePage.vue
@@ -1,0 +1,8 @@
+<template>
+</template>
+
+<script>
+</script>
+
+<style scoped>
+</style>

--- a/app/javascript/end_user/TalkThemeRoulettePage.vue
+++ b/app/javascript/end_user/TalkThemeRoulettePage.vue
@@ -1,8 +1,167 @@
 <template>
+  <Header>B I L B I L</Header>
+  <main class="container my-5">
+    <div class="row mb-5">
+      <div class="col-12 col-sm-6 mx-auto">
+        <div class="mb-3">
+            <router-link class="py-1" to="/content"
+              >トークテーマの確認はこちらから。</router-link
+            >
+        </div>
+        <head-line>TALK THEME</head-line>
+        <div class="fs-5 mb-3">カテゴリーを選んでください</div>
+        <div class="d-flex flex-wrap mb-3">
+          <div
+            class="me-3"
+            v-for="(category, index) in categories"
+            :key="category.id"
+          >
+            <input
+              type="radio"
+              class="btn-check"
+              name="category"
+              :id="[`category` + index]"
+              :value="category.id"
+              v-model="category_id"
+              autocomplete="off"
+            />
+            <label
+              class="btn btn-outline-secondary"
+              :for="[`category` + index]"
+              >{{ category.name }}</label
+            >
+          </div>
+        </div>
+        <div class="fs-5">
+          {{ category_name }}トーク
+        </div>
+        <div class="talk_theme_roulette p-5 mb-3 fs-5 fw-bold">
+          <span v-if="this.talk_theme != undefined">
+            {{ talk_theme.content }} ?
+          </span>
+          <span v-else>トークはありません。</span>
+        </div>
+        <div class="text-center">
+          <div
+            class="d-inline-block text-white"
+            @click="
+              roulette();
+              active();
+            "
+          >
+            <div class="start_btn p-3" v-if="this.is_active">
+              <i class="fa-solid fa-circle-stop me-2"></i>
+              <span>ストップ</span>
+            </div>
+            <div class="stop_btn p-3" v-else>
+              <i class="fa-solid fa-arrows-rotate me-2"></i>
+              <span>スタート</span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col-12 col-sm-6 mx-auto">
+        <div class="mb-3">
+          <head-line>TALK SUPPORT</head-line>
+        </div>
+      </div>
+    </div>
+  </main>
+  <Footer></Footer>
 </template>
 
 <script>
+import axios from "axios";
+
+import Header from "../components/Header.vue";
+import HeadLine from "../components/Headline.vue";
+import Footer from "../components/Footer.vue";
+
+export default {
+  components: {
+    Header,
+    HeadLine,
+    Footer,
+  },
+  data() {
+    return {
+      categories: {},
+      category_id: "",
+      talk_theme: {},
+      is_active: false,
+    };
+  },
+  computed: {
+    category_name() {
+      const category = this.categories.find(category => category.id == this.category_id);
+      return category.name;
+    },
+  },
+  created() {
+    axios
+      .get("/api/v1/categories")
+      .then((response) => {
+        this.categories = response.data;
+        this.category_id = this.categories[0].id;
+      })
+      .then(() => {
+        this.talkThemes();
+      });
+  },
+  watch: {
+    category_id: function () {
+      this.talkThemes();
+    },
+  },
+  methods: {
+    talkThemes: function () {
+      let talk_themes = [];
+      this.categories.forEach((category) => {
+        if (category.id == this.category_id) {
+          talk_themes = category.talk_themes;
+          this.talk_theme =
+            talk_themes[Math.floor(Math.random() * talk_themes.length)];
+        }
+      });
+    },
+    active() {
+      this.is_active = !this.is_active;
+    },
+    roulette: function () {
+      let roulette = setInterval(() => {
+        if (this.is_active) {
+          this.talkThemes();
+        } else {
+          clearInterval(roulette);
+        }
+      }, 100);
+    },
+  },
+};
 </script>
 
 <style scoped>
+.btn-outline-secondary {
+  width: 80px;
+  border-radius: 40px;
+}
+
+.talk_theme_roulette {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  border: 1px solid #000;
+  border-radius: 5px;
+}
+
+.start_btn {
+  background-color: #0070f3;
+  border-radius: 10px;
+}
+.stop_btn {
+  background-color: #ff5858;
+  border-radius: 10px;
+}
 </style>

--- a/app/javascript/packs/router/end-user-router.js
+++ b/app/javascript/packs/router/end-user-router.js
@@ -1,8 +1,11 @@
 import { createRouter, createWebHashHistory } from "vue-router";
+import TalkThemeRoulettePage from "../../end_user/TalkThemeRoulettePage.vue";
 import ContentIndexPage from "../../end_user/ContentIndexPage.vue";
 
 const routes = [
   { path: "/", 
+    component: TalkThemeRoulettePage },
+  { path: "/content", 
     component: ContentIndexPage },
 ]
 


### PR DESCRIPTION
## 変更の概要
会話サポートルーレット画面にトークテーマルーレットを作成する。

## なぜこの変更をするのか
トークテーマルーレットでトークテーマを提供できるようにするため。

## やったこと
1.  axiosで各カテゴリーのトークテーマデータを取得する。
2. カテゴリー名が書かれたラジオボタンを作成し、ラジオボタンの値によって、トークテーマが差し替わるようにする。
3. トークテーマの表示を細かく変化させるための関数を作成する。
4. トークテーマの表示の変更を停止させるための関数を作成する。
5. ルーレットスタート・ストップボタンを作成する。

## 関連issue
- #34 