### PR TITLE
feat: デプロイを行えるように設定を加える。

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ ruby '3.1.2'
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails', branch: 'main'
 gem 'rails', '~> 6.1.7'
 # Use sqlite3 as the database for Active Record
-gem 'sqlite3', '~> 1.4'
+# gem 'sqlite3', '~> 1.4'
 # Use Puma as the app server
 gem 'puma', '~> 5.0'
 # Use SCSS for stylesheets
@@ -47,11 +47,16 @@ group :development do
 end
 
 group :test do
+  gem 'sqlite3', '~> 1.4'
   # Adds support for Capybara system testing and selenium driver
   gem 'capybara', '>= 3.26'
   gem 'selenium-webdriver', '>= 4.0.0.rc1'
   # Easy installation and use of web drivers to run system tests with browsers
   gem 'webdrivers'
+end
+
+group :production do
+  gem 'pg', '1.1.4'
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -129,6 +129,7 @@ GEM
     nokogiri (1.13.8-x86_64-linux)
       racc (~> 1.4)
     orm_adapter (0.5.0)
+    pg (1.1.4)
     pry (0.14.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -254,6 +255,7 @@ DEPENDENCIES
   jbuilder (~> 2.7)
   listen (~> 3.3)
   net-smtp
+  pg (= 1.1.4)
   pry-byebug
   puma (~> 5.0)
   rack-mini-profiler (~> 2.0)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,3 @@
 class ApplicationController < ActionController::Base
+  protect_from_forgery with: :null_session
 end

--- a/app/javascript/packs/router/admin-router.js
+++ b/app/javascript/packs/router/admin-router.js
@@ -1,24 +1,24 @@
-import { createRouter, createWebHashHistory } from "vue-router";
+import { createRouter, createWebHistory } from "vue-router";
 import ContentIndexPage from "../../admin/ContentIndexPage.vue";
 import ContentNewPage from "../../admin/ContentNewPage.vue";
 import CategoryEditPage from "../../admin/CategoryEditPage.vue";
 import TalkThemeEditPage from "../../admin/TalkThemeEditPage.vue";
 
 const routes = [
-  { path: "/", 
+  { path: "/admin", 
     component: ContentIndexPage },
-  { path: "/content/new", 
+  { path: "/admin/content/new", 
     component: ContentNewPage },
-  { path: '/categories/:id(\\d+)/edit',
+  { path: '/admin/categories/:id(\\d+)/edit',
     name: 'CategoryEditPage',
     component: CategoryEditPage  },
-  { path: '/talk_themes/:id(\\d+)/edit',
+  { path: '/admin/talk_themes/:id(\\d+)/edit',
     name: 'TalkThemeEditPage',
     component: TalkThemeEditPage  },
 ]
 
 const router = createRouter({
-  history: createWebHashHistory(),
+  history: createWebHistory(),
   routes,
 });
 

--- a/app/javascript/packs/router/end-user-router.js
+++ b/app/javascript/packs/router/end-user-router.js
@@ -1,4 +1,4 @@
-import { createRouter, createWebHashHistory } from "vue-router";
+import { createRouter, createWebHistory } from "vue-router";
 import TalkThemeRoulettePage from "../../end_user/TalkThemeRoulettePage.vue";
 import ContentIndexPage from "../../end_user/ContentIndexPage.vue";
 
@@ -10,7 +10,7 @@ const routes = [
 ]
 
 const router = createRouter({
-  history: createWebHashHistory(),
+  history: createWebHistory(),
   routes,
 });
 

--- a/config/database.yml
+++ b/config/database.yml
@@ -22,4 +22,6 @@ test:
 
 production:
   <<: *default
-  database: db/production.sqlite3
+  adapter: postgresql
+  encoding: unicode
+  pool: 5

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,10 +5,14 @@ Rails.application.routes.draw do
   
   namespace :admin do
     root 'homes#top'
+    get 'content/new', to: 'homes#top'
+    get '/categories/:id/edit', to: 'homes#top'
+    get '/talk_themes/:id/edit', to: 'homes#top'
   end
   
   scope module: :end_user do
     root 'homes#top'
+    get 'content', to: 'homes#top'
   end
 
   namespace :api, {format: 'json'} do
@@ -23,5 +27,9 @@ Rails.application.routes.draw do
       end
       get 'like/ip' => 'likes#ip'
     end
+  end
+
+  if Rails.env.production?
+    match "*path" , to: redirect('/'), via: 'get'
   end
 end


### PR DESCRIPTION
## 変更の概要
デプロイを行えるように設定を加える。

## なぜこの変更をするのか
本番環境でこのアプリを実際に動かせるようにするため。

## やったこと
1.  urlに#がつかないようにする。
2.  存在しないurlをアドレスバーに入れた際に、ルートパスに遷移するようにする。
3.  herokuでデプロイするため、PostgreSQLの設定を行う。

## 関連issue
- #36 