### PR TITLE
feat: ルーレットの使用方法説明画面を作成する。

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 <h2 align="center">bilbil - ビルビル</h2>
 
-## **アプリ** 🏢
-スムーズに会話を進めたいが、会話を上手く進められない人のためのアプリ「bilbil」
-
 <div align="center">
 <img src="https://qiita-image-store.s3.ap-northeast-1.amazonaws.com/0/2626303/25a1305e-0a03-13e2-f522-e124074b198c.jpeg" height=300px;/>
 </div>
+
+## **アプリ** 🏢
+スムーズに会話を進めたいが、会話を上手く進められない人のためのアプリ「bilbil」
 
 ## **アプリ概要** 🗺️
  **｢bilbil｣** ("ビルビル")はスムーズに会話を進めたいけど、それがなかなか上手くいかない人のために **｢ルーレット｣** を使って、**トークテーマや話す順番などを提案してくれる**会話サポートアプリです。
@@ -16,9 +16,11 @@
 
 このアプリが提供した会話サポートによって、スムーズに会話が進み、会話の参加者間で良い雰囲気ができることを願っているので、**このアプリの会話サポートによる会話の流れのbil(作成)** と**会話の参加者間の良い雰囲気のbil(作る)** を組み合わせて**bilbil**としました。
 
-**アプリURL :** https://bil-bil.herokuapp.com/
+**アプリURL :**<br />
+https://bil-bil.herokuapp.com/
 
-<img src="https://img.shields.io/badge/-%E8%A8%98%E4%BA%8B-55C500.svg?logo=qiita&style=social"> **:** [【個人開発】スムーズに会話を進めたいが、会話を上手く進められない人のためのアプリ「bilbil」を紹介します。](https://qiita.com/icchankun/items/68dad4c0bdc1e52b684a)
+**Qiita記事:** <br />
+[【個人開発】スムーズに会話を進めたいが、会話を上手く進められない人のためのアプリ「bilbil」を紹介します。](https://qiita.com/icchankun/items/68dad4c0bdc1e52b684a)
 
 ## **ターゲット** 👪
 - トークテーマが考えつかず、困っている人

--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -26,3 +26,9 @@ body {
   position: absolute;
   bottom: 0;
 }
+
+@media (max-width: 500px) {
+  .end_user {
+    padding-bottom: 450px;
+  }
+}

--- a/app/javascript/end_user/ContentIndexPage.vue
+++ b/app/javascript/end_user/ContentIndexPage.vue
@@ -3,7 +3,14 @@
   <main class="container">
     <div class="row my-5">
       <div class="col-lg-6 mx-auto">
-        <root-path-button>トップページに戻る</root-path-button>
+        <div>
+          <div class="mb-3 text-center">
+            <router-link class="py-1" to="/guide"
+              >ご利用ガイドはこちらから。</router-link
+            >
+          </div>
+          <root-path-button>ルーレットページに戻る</root-path-button>
+        </div>
         <div class="mt-5">
           <div
             class="row dropdown"

--- a/app/javascript/end_user/HowToUsePage.vue
+++ b/app/javascript/end_user/HowToUsePage.vue
@@ -1,0 +1,184 @@
+<template>
+  <Header>G U I D E</Header>
+  <main class="container my-5">
+    <div class="row">
+      <div class="col-12 col-lg-7 mx-auto">
+        <head-line>TALK THEME</head-line>
+        <div class="description d-flex flex-column mx-auto mb-5">
+          <div class="mb-3">
+            <div class="mb-2">
+              1.お好きなトークテーマカテゴリーを選択します。
+              <div class="fw-normal">※選択したボタンは色が変わります。</div>
+            </div>
+            <div class="d-flex flex-wrap">
+              <div
+                class="me-3"
+                v-for="(category, index) in categories"
+                :key="category.id"
+              >
+                <input
+                  type="radio"
+                  class="btn-check"
+                  name="category"
+                  :id="[`category` + index]"
+                  :value="category.id"
+                  v-model="category_id"
+                  autocomplete="off"
+                />
+                <label
+                  class="btn btn-outline-secondary category_btn"
+                  :for="[`category` + index]"
+                  >{{ category.name }}</label
+                >
+              </div>
+            </div>
+          </div>
+          <div class="mb-3">
+            <div class="mb-2">
+              2. ルーレットの右にあるボタンを押します。
+              <div class="fw-normal">※トークテーマルーレットのボタンは下にあります。</div>
+            </div>
+            <div class="row">
+              <div class="d-flex col-12 col-lg-6 mb-3 fw-normal">
+                <div class="stop_btn">
+                  <i class="fas fa-sync-alt"></i>
+                </div>
+                <span class="p-2">スタートボタン</span>
+              </div>
+              <div class="d-flex col-12 col-lg-6 mb-3 fw-normal">
+                <div class="start_btn">
+                  <i class="fas fa-stop-circle"></i>
+                </div>
+                <span class="p-2">ストップボタン</span>
+              </div>
+            </div>
+          </div>
+          <div>3. 止まったテーマでトークをします。</div>
+        </div>
+        <head-line>TALK SUPPORT</head-line>
+        <div class="description d-flex flex-column mx-auto mb-5">
+          <div class="mb-3">
+            <div class="mb-2">
+              1. トーク人数のボタンを押します。
+              <div class="fw-normal">※選択したボタンは色が変わります。</div>
+            </div>
+            <div class="d-flex flex-wrap justify-content-start">
+              <div class="me-3" v-for="n in 9" :key="n">
+                <input
+                  type="radio"
+                  class="btn-check"
+                  :name="n + 1"
+                  :id="n + 1"
+                  :value="n + 1"
+                  v-model="number_of_people"
+                  autocomplete="off"
+                />
+                <label
+                  class="btn btn-outline-secondary number_btn mb-3"
+                  :for="n + 1"
+                  >{{ n + 1 }}</label
+                >
+              </div>
+            </div>
+          </div>
+          <div class="mb-3">
+            2. 番号指定ルーレットの指示に従って、各参加者に番号を振ります。
+          </div>
+          <div class="mb-3">
+            3. 使いたいトークサポートルーレットを回します。
+          </div>
+          <div class="mb-3">
+            <div class="mb-2">
+              <div>トーク順番ルーレット</div>
+              <div class="fw-normal">
+                番号指定ルーレットで決めた番号をもとにトーク順番を決定します。
+              </div>
+            </div>
+            <div>
+              <div>司会者ルーレット</div>
+              <div class="fw-normal">
+                司会者を決めるためのルーレットです。<br />
+                司会者とは、なっていますが、発表者を決める際などにも使用できます。<br />
+                ※2人の時は、司会者ルーレットは表示されません。
+              </div>
+            </div>
+          </div>
+          <div>4. 止まった指示に従って、トークをします。</div>
+        </div>
+        <div class="text-center mb-3">
+          <router-link class="py-1" to="/content"
+            >トークテーマの確認はこちらから。</router-link
+          >
+        </div>
+        <root-path-button>ルーレットページに戻る</root-path-button>
+      </div>
+    </div>
+  </main>
+  <end-user-footer>
+    トークテーマルーレットだけでも利用できますが、トークサポートルーレットも<br />
+    合わせて利用していただくことをおすすめします。
+  </end-user-footer>
+</template>
+
+<script>
+import axios from "axios";
+
+import Header from "../components/Header.vue";
+import HeadLine from "../components/Headline.vue";
+import RootPathButton from "../components/RootPathButton.vue";
+import EndUserFooter from "../components/EndUserFooter.vue";
+
+export default {
+  components: {
+    Header,
+    HeadLine,
+    RootPathButton,
+    EndUserFooter,
+  },
+  created() {
+    axios.get("/api/v1/categories").then((response) => {
+      this.categories = response.data;
+      this.category_id = this.categories[0].id;
+    });
+  },
+  data() {
+    return {
+      categories: [],
+      category_id: "",
+      number_of_people: 2,
+    };
+  },
+};
+</script>
+
+<style scoped>
+.description {
+  width: 80%;
+  font-weight: bold;
+}
+.category_btn {
+  width: 80px;
+  border-radius: 40px;
+}
+
+.number_btn {
+  border-radius: 10px;
+  font-weight: bold;
+}
+.start_btn {
+  background-color: #0070f3;
+  width: 40px;
+  color: #fff;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+.stop_btn {
+  background-color: #ff5858;
+  color: #fff;
+  width: 40px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+</style>

--- a/app/javascript/end_user/RoulettePage.vue
+++ b/app/javascript/end_user/RoulettePage.vue
@@ -4,9 +4,16 @@
     <div class="row">
       <div class="col-12 col-sm-7 mx-auto">
         <div class="mb-3">
-          <router-link class="py-1" to="/content"
-            >トークテーマの確認はこちらから。</router-link
-          >
+          <div class="mb-2">
+            <router-link class="py-1" to="/guide"
+              >ご利用ガイドはこちらから。</router-link
+            >
+          </div>
+          <div>
+            <router-link class="py-1" to="/content"
+              >トークテーマの確認はこちらから。</router-link
+            >
+          </div>
         </div>
         <div class="px-1 mb-5">
           <head-line>TALK THEME</head-line>

--- a/app/javascript/packs/router/end-user-router.js
+++ b/app/javascript/packs/router/end-user-router.js
@@ -1,12 +1,15 @@
 import { createRouter, createWebHistory } from "vue-router";
 import RoulettePage from "../../end_user/RoulettePage.vue";
 import ContentIndexPage from "../../end_user/ContentIndexPage.vue";
+import HowToUsePage from "../../end_user/HowToUsePage.vue";
 
 const routes = [
   { path: "/", 
     component: RoulettePage },
   { path: "/content", 
     component: ContentIndexPage },
+  { path: "/guide", 
+    component: HowToUsePage },
 ]
 
 const router = createRouter({

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,7 @@ Rails.application.routes.draw do
   scope module: :end_user do
     root 'homes#top'
     get 'content', to: 'homes#top'
+    get 'guide', to: 'homes#top'
   end
 
   namespace :api, {format: 'json'} do

--- a/db/fixtures/production/category.rb
+++ b/db/fixtures/production/category.rb
@@ -1,0 +1,4 @@
+Category.seed do |s|
+  s.id    = 1
+  s.name = '定番'
+end


### PR DESCRIPTION
## 変更の概要
ルーレットの使用方法説明画面を作成する。

## なぜこの変更をするのか
トークテーマ・会話サポートルーレットの使用方法を分かりやすく伝えるため。

## やったこと
1. モックアップの使用方法画面のデザインに沿って、画面を作成する。

## 関連issue
- #42 