### PR TITLE
feat: トークテーマ・カテゴリーを新規作成した後、その内容をコンテンツ新規登録画面上部に表示させるようにする。

### DIFF
--- a/app/controllers/api/v1/categories_controller.rb
+++ b/app/controllers/api/v1/categories_controller.rb
@@ -19,7 +19,7 @@ class Api::V1::CategoriesController < ApiController
   def create
     category =  Category.new(category_params)
     if category.save
-      head :created
+      render json: category
     else
       render json: { errors:  category.errors.full_messages }, status: :unprocessable_entity
     end

--- a/app/controllers/api/v1/talk_themes_controller.rb
+++ b/app/controllers/api/v1/talk_themes_controller.rb
@@ -19,7 +19,7 @@ class Api::V1::TalkThemesController < ApiController
   def create
     talk_theme =  TalkTheme.new(talk_theme_params)
     if talk_theme.save
-      head :created
+      render json: talk_theme
     else
       render json: { errors:  talk_theme.errors.full_messages }, status: :unprocessable_entity
     end

--- a/app/javascript/admin/ContentNewPage.vue
+++ b/app/javascript/admin/ContentNewPage.vue
@@ -1,13 +1,12 @@
 <template>
   <Header>C R E A T E</Header>
-
   <div class="container">
     <div class="row my-5">
-      <div class="col-lg-6 col-sm-12 mx-auto">
+      <div class="col-12 col-lg-6 mx-auto">
         <headline>THEHE</headline>
         <div>
-          {{ create_talk_theme.content }}
-          {{ create_talk_theme.category }}
+          {{ created_talk_theme.content }}
+          {{ created_talk_theme.category }}
         </div>
         <talk-theme-form-pane
           :talk_theme="talk_theme"
@@ -18,7 +17,7 @@
         >
         <headline>CATEGORY</headline>
         <div>
-          {{ create_category.name }}
+          {{ created_category.name }}
         </div>
         <category-form-pane
           :category="category"
@@ -59,20 +58,20 @@ export default {
         category_id: "",
         errors: "",
       },
-      create_talk_theme: {},
+      created_talk_theme: {},
       category: {
         name: "",
         errors: "",
       },
-      create_category: {},
+      created_category: {},
       categories: {},
     };
   },
   mounted() {
     // 全カテゴリーを取得する
-    axios
-      .get("/api/v1/categories")
-      .then((response) => (this.categories = response.data));
+    axios.get("/api/v1/categories").then((response) => {
+      this.categories = response.data;
+    });
   },
   methods: {
     // トークテーマを新規登録する
@@ -83,13 +82,24 @@ export default {
           category_id: this.talk_theme.category_id,
         })
         .then((response) => {
-          this.create_talk_theme = response.data;
+          this.created_talk_theme = response.data;
+
+          // フォームを初期状態に戻す。
+          this.talk_theme.content = "";
+          this.talk_theme.category_id = "";
+
+          // エラーメッセージを削除する。
+          this.talk_theme.errors = "";
+
           this.categoryName();
           this.$router.push({ path: "/admin/content/new" });
         })
         .catch((error) => {
           console.error(error);
           if (error.response.data && error.response.data.errors) {
+            // 作成したトークテーマの表示を止める。
+            this.created_talk_theme = "";
+
             this.talk_theme.errors = error.response.data.errors;
           }
         });
@@ -100,12 +110,22 @@ export default {
       axios
         .post("/api/v1/categories", { name: this.category.name })
         .then((response) => {
-          this.create_category = response.data;
+          this.created_category = response.data;
+
+          // フォームを初期状態に戻す。
+          this.category.name = "";
+
+          // エラーメッセージを削除する。
+          this.category.errors = "";
+
           this.$router.push({ path: "/admin/content/new" });
         })
         .catch((error) => {
           console.error(error);
           if (error.response.data && error.response.data.errors) {
+            // 作成したカテゴリーの表示を止める。
+            this.created_category = "";
+
             this.category.errors = error.response.data.errors;
           }
         });
@@ -114,9 +134,9 @@ export default {
     // 新規登録したトークテーマのカテゴリー名を取得する。
     categoryName() {
       const filterDate = this.categories.filter(
-        (category) => category.id === this.create_talk_theme.category_id
+        (category) => category.id === this.created_talk_theme.category_id
       );
-      this.create_talk_theme.category = filterDate[0].name;
+      this.created_talk_theme.category = filterDate[0].name;
     },
   },
 };

--- a/app/javascript/admin/ContentNewPage.vue
+++ b/app/javascript/admin/ContentNewPage.vue
@@ -5,6 +5,10 @@
     <div class="row my-5">
       <div class="col-lg-6 col-sm-12 mx-auto">
         <headline>THEHE</headline>
+        <div>
+          {{ create_talk_theme.content }}
+          {{ create_talk_theme.category }}
+        </div>
         <talk-theme-form-pane
           :talk_theme="talk_theme"
           :categories="categories"
@@ -13,6 +17,9 @@
           >トークテーマを作成</talk-theme-form-pane
         >
         <headline>CATEGORY</headline>
+        <div>
+          {{ create_category.name }}
+        </div>
         <category-form-pane
           :category="category"
           :errors="category.errors"
@@ -52,27 +59,33 @@ export default {
         category_id: "",
         errors: "",
       },
+      create_talk_theme: {},
       category: {
         name: "",
         errors: "",
       },
+      create_category: {},
       categories: {},
     };
   },
   mounted() {
+    // 全カテゴリーを取得する
     axios
       .get("/api/v1/categories")
       .then((response) => (this.categories = response.data));
   },
   methods: {
-    createTalkTheme: function () {
+    // トークテーマを新規登録する
+    createTalkTheme() {
       axios
         .post("/api/v1/talk_themes", {
           content: this.talk_theme.content,
           category_id: this.talk_theme.category_id,
         })
-        .then(() => {
-          this.$router.push({ path: "/admin" });
+        .then((response) => {
+          this.create_talk_theme = response.data;
+          this.categoryName();
+          this.$router.push({ path: "/admin/content/new" });
         })
         .catch((error) => {
           console.error(error);
@@ -81,11 +94,14 @@ export default {
           }
         });
     },
-    createCategory: function () {
+
+    // カテゴリーを新規登録する。
+    createCategory() {
       axios
         .post("/api/v1/categories", { name: this.category.name })
-        .then(() => {
-          this.$router.push({ path: "/" });
+        .then((response) => {
+          this.create_category = response.data;
+          this.$router.push({ path: "/admin/content/new" });
         })
         .catch((error) => {
           console.error(error);
@@ -93,6 +109,14 @@ export default {
             this.category.errors = error.response.data.errors;
           }
         });
+    },
+
+    // 新規登録したトークテーマのカテゴリー名を取得する。
+    categoryName() {
+      const filterDate = this.categories.filter(
+        (category) => category.id === this.create_talk_theme.category_id
+      );
+      this.create_talk_theme.category = filterDate[0].name;
     },
   },
 };

--- a/app/javascript/admin/ContentNewPage.vue
+++ b/app/javascript/admin/ContentNewPage.vue
@@ -4,9 +4,17 @@
     <div class="row my-5">
       <div class="col-12 col-lg-6 mx-auto">
         <headline>THEHE</headline>
-        <div>
+        <div v-if="Boolean(created_talk_theme.content)">
           {{ created_talk_theme.content }}
           {{ created_talk_theme.category }}
+          <router-link
+            class=""
+            :to="{
+              name: 'TalkThemeEditPage',
+              params: { id: created_talk_theme.id },
+            }"
+            >編集</router-link
+          >
         </div>
         <talk-theme-form-pane
           :talk_theme="talk_theme"
@@ -16,8 +24,16 @@
           >トークテーマを作成</talk-theme-form-pane
         >
         <headline>CATEGORY</headline>
-        <div>
+        <div v-if="Boolean(created_category.name)">
           {{ created_category.name }}
+          <router-link
+            class=""
+            :to="{
+              name: 'CategoryEditPage',
+              params: { id: created_category.id },
+            }"
+            >編集</router-link
+          >
         </div>
         <category-form-pane
           :category="category"

--- a/app/javascript/admin/ContentNewPage.vue
+++ b/app/javascript/admin/ContentNewPage.vue
@@ -4,17 +4,23 @@
     <div class="row my-5">
       <div class="col-12 col-lg-6 mx-auto">
         <headline>THEHE</headline>
-        <div v-if="Boolean(created_talk_theme.content)">
-          {{ created_talk_theme.content }}
-          {{ created_talk_theme.category }}
-          <router-link
-            class=""
-            :to="{
-              name: 'TalkThemeEditPage',
-              params: { id: created_talk_theme.id },
-            }"
-            >編集</router-link
-          >
+        <div class="alert alert-success" v-if="Boolean(created_talk_theme.content)">
+          <dl class="d-flex flex-wrap justify-content-between m-0">
+            <dt class="d-inline-block">
+              <div>トークテーマ: {{ created_talk_theme.content }}</div>
+              <div>カテゴリー名: {{ created_talk_theme.category }}</div>
+            </dt>
+            <dd class="d-inline-block m-0">
+              <router-link
+                class="btn btn-success"
+                :to="{
+                  name: 'TalkThemeEditPage',
+                  params: { id: created_talk_theme.id },
+                }"
+                >編集</router-link
+              >
+            </dd>
+          </dl>
         </div>
         <talk-theme-form-pane
           :talk_theme="talk_theme"
@@ -24,16 +30,22 @@
           >トークテーマを作成</talk-theme-form-pane
         >
         <headline>CATEGORY</headline>
-        <div v-if="Boolean(created_category.name)">
-          {{ created_category.name }}
-          <router-link
-            class=""
-            :to="{
-              name: 'CategoryEditPage',
-              params: { id: created_category.id },
-            }"
-            >編集</router-link
-          >
+        <div class="alert alert-success" v-if="Boolean(created_category.name)">
+          <dl class="d-flex flex-wrap justify-content-between m-0">
+            <dt class="d-inline-block">
+              <div>カテゴリー: {{ created_category.name }}</div>
+            </dt>
+            <dd class="d-inline-block m-0">
+              <router-link
+                class="btn btn-success"
+                :to="{
+                  name: 'CategoryEditPage',
+                  params: { id: created_category.id },
+                }"
+                >編集</router-link
+              >
+            </dd>
+          </dl>
         </div>
         <category-form-pane
           :category="category"

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,4 +1,4 @@
 class Category < ApplicationRecord
   has_many :talk_themes
-  validates :name, presence: true
+  validates :name, presence: true, length: { in: 2..4 }, uniqueness: true
 end

--- a/app/models/like.rb
+++ b/app/models/like.rb
@@ -1,3 +1,4 @@
 class Like < ApplicationRecord
   belongs_to :talk_theme
+  validates :talk_theme_id, uniqueness: { scope: :ip }
 end

--- a/app/models/talk_theme.rb
+++ b/app/models/talk_theme.rb
@@ -1,5 +1,5 @@
 class TalkTheme < ApplicationRecord
   belongs_to :category
   has_many :likes, dependent: :destroy
-  validates :content, presence: true
+  validates :content, presence: true, length: { in: 4..30 }, uniqueness: true
 end

--- a/app/views/admin/sessions/new.html.erb
+++ b/app/views/admin/sessions/new.html.erb
@@ -5,7 +5,7 @@
     <div class="container p-2">
       <div class="text-center">
         <h1 class="text-white fw-bold">
-          S I G N I N
+          L O G I N
         </h1>
       </div>
     </div>
@@ -32,8 +32,8 @@
         </div>
         <% end %>
 
-        <div class="actions">
-          <%= f.submit "サインインする" , class: "btn btn-success"%>
+        <div class="actions text-center">
+          <%= f.submit "ログインする" , class: "btn btn-success"%>
         </div>
         <% end %>
 


### PR DESCRIPTION
## 変更の概要
トークテーマ・カテゴリーを新規作成した後、その内容をコンテンツ新規登録画面上部に表示させるようにする。

## なぜこの変更をするのか
新規登録したトークテーマ・カテゴリーに間違いがないかどうかを確認しやすくするため。

## やったこと
1. 新規登録されたトークテーマ・カテゴリーのデータをjsonデータで返す。
2. axiosを使用し、そのデータを取得する。
3. そのデータを画面上部に表示させる。

## 関連issue
- #50 