### PR TITLE
feat: 会話サポートルーレットの説明をモーダルウィンドウで表示できるようにする。

### DIFF
--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -29,6 +29,6 @@ body {
 
 @media (max-width: 800px) {
   .end_user {
-    padding-bottom: 450px;
+    padding-bottom: 500px;
   }
 }

--- a/app/javascript/components/HostRoulette.vue
+++ b/app/javascript/components/HostRoulette.vue
@@ -39,6 +39,7 @@ export default {
     return {
       host: {},
       is_active: false,
+      roulette_type: "host",
     };
   },
   watch: {
@@ -67,7 +68,7 @@ export default {
       }, 100);
     },
     clickEvent() {
-      this.$emit("openModal");
+      this.$emit("openModal", this.roulette_type);
     },
   },
 };

--- a/app/javascript/components/HostRoulette.vue
+++ b/app/javascript/components/HostRoulette.vue
@@ -72,16 +72,4 @@ export default {
   font-weight: bold;
   text-align: center;
 }
-.start_btn {
-  background-color: #0070f3;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-}
-.stop_btn {
-  background-color: #ff5858;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-}
 </style>

--- a/app/javascript/components/HostRoulette.vue
+++ b/app/javascript/components/HostRoulette.vue
@@ -1,6 +1,9 @@
 <template>
   <div>
-    <div class="fs-5">司会者・話し手指定</div>
+    <div>
+      <span class="fs-5">司会者・話し手指定</span>
+      <span @click="clickEvent">?</span>
+    </div>
     <div class="row">
       <div class="col-7 p-2 host_roulette">
         {{ host }}
@@ -31,6 +34,7 @@ export default {
   props: {
     number_of_people: "",
   },
+  emits: ["openModal"],
   data() {
     return {
       host: {},
@@ -61,6 +65,9 @@ export default {
           clearInterval(roulette);
         }
       }, 100);
+    },
+    clickEvent() {
+      this.$emit("openModal");
     },
   },
 };

--- a/app/javascript/components/HostRoulette.vue
+++ b/app/javascript/components/HostRoulette.vue
@@ -1,26 +1,24 @@
 <template>
-  <div>
-    <div>
-      <span class="fs-5">司会者・話し手指定</span>
-      <span @click="clickEvent">?</span>
+  <div class="mb-2">
+    <span class="fs-5 me-2">司会者・話し手指定</span>
+    <span class="modal_btn" @click="clickEvent">?</span>
+  </div>
+  <div class="row">
+    <div class="col-7 p-2 host_roulette">
+      {{ host }}
     </div>
-    <div class="row">
-      <div class="col-7 p-2 host_roulette">
-        {{ host }}
+    <div
+      class="col-3 text-white px-0"
+      @click="
+        roulette();
+        active();
+      "
+    >
+      <div class="start_btn h-100" v-if="this.is_active">
+        <i class="fas fa-stop-circle"></i>
       </div>
-      <div
-        class="col-3 text-white px-0"
-        @click="
-          roulette();
-          active();
-        "
-      >
-        <div class="start_btn h-100" v-if="this.is_active">
-          <i class="fas fa-stop-circle"></i>
-        </div>
-        <div class="stop_btn h-100" v-else>
-          <i class="fas fa-sync-alt"></i>
-        </div>
+      <div class="stop_btn h-100" v-else>
+        <i class="fas fa-sync-alt"></i>
       </div>
     </div>
   </div>

--- a/app/javascript/components/HostRoulette.vue
+++ b/app/javascript/components/HostRoulette.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <div class="fs-5">司会者</div>
+    <div class="fs-5">司会者・話し手指定</div>
     <div class="row">
       <div class="col-7 p-2 host_roulette">
         {{ host }}

--- a/app/javascript/components/ModalWindow.vue
+++ b/app/javascript/components/ModalWindow.vue
@@ -1,0 +1,46 @@
+<template>
+  <div v-if="show_content" id="overlay">
+    <div id="content">
+      <p v-if="roulette_type == 'number_assignment'">番号指定ルーレット</p>
+      <p v-else-if="roulette_type == 'talk_order'">トーク順番ルーレット</p>
+      <p v-else>司会者・話し手ルーレット</p>
+      <p><button @click="clickEvent">close</button></p>
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  props: {
+    show_content: "",
+    roulette_type: "",
+  },
+  emits: ["closeModal"],
+  methods: {
+    clickEvent() {
+      this.$emit("closeModal");
+    },
+  },
+};
+</script>
+
+<style scoped>
+#overlay {
+  z-index: 1;
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+#content {
+  z-index: 2;
+  width: 50%;
+  padding: 1em;
+  background: #fff;
+}
+</style>

--- a/app/javascript/components/ModalWindow.vue
+++ b/app/javascript/components/ModalWindow.vue
@@ -1,10 +1,27 @@
 <template>
   <div v-if="show_content" id="overlay">
-    <div id="content">
-      <p v-if="roulette_type == 'number_assignment'">番号指定ルーレット</p>
-      <p v-else-if="roulette_type == 'talk_order'">トーク順番ルーレット</p>
-      <p v-else>司会者・話し手ルーレット</p>
-      <p><button @click="clickEvent">close</button></p>
+    <div class="modal_window">
+      <div v-if="roulette_type == 'number_assignment'">
+        <h3 class="mb-3">番号指定ルーレット</h3>
+        <div class="mb-3">
+          このルーレットの指示で各参加者に番号を振ります。<br />
+          例)「誕生日が早い順」とルーレットに表示された場合は、誕生日が早い順に1,
+          2と各参加者に番号を振っていきます。
+        </div>
+      </div>
+      <div v-else-if="roulette_type == 'talk_order'">
+        <h3 class="mb-2">トーク順番ルーレット</h3>
+        <div class="mb-3">
+          このルーレットの指示と番号指定ルーレットによって決めた番号をもとにトークする順番を決めてください。
+        </div>
+      </div>
+      <div v-else>
+        <h3 class="mb-2">司会者・話し手ルーレット</h3>
+        <div class="mb-3">
+          このルーレットの指示と番号指定ルーレットによって決めた番号をもとに司会者や話し手を決めることもできます。
+        </div>
+      </div>
+      <span class="btn btn-primary" @click="clickEvent">閉じる</span>
     </div>
   </div>
 </template>
@@ -37,9 +54,8 @@ export default {
   align-items: center;
   justify-content: center;
 }
-#content {
+.modal_window {
   z-index: 2;
-  width: 50%;
   padding: 1em;
   background: #fff;
 }

--- a/app/javascript/components/NumberAssignmentRoulette.vue
+++ b/app/javascript/components/NumberAssignmentRoulette.vue
@@ -1,8 +1,8 @@
 <template>
   <div class="mb-3">
-    <div>
-      <span class="fs-5">番号指定</span>
-      <span @click="clickEvent">?</span>
+    <div class="mb-2">
+      <span class="fs-5 me-2">番号指定</span>
+      <span class="modal_btn" @click="clickEvent">?</span>
     </div>
     <div class="row">
       <div class="col-11 p-2 number_assignment_roulette">

--- a/app/javascript/components/NumberAssignmentRoulette.vue
+++ b/app/javascript/components/NumberAssignmentRoulette.vue
@@ -71,16 +71,4 @@ export default {
   font-weight: bold;
   text-align: center;
 }
-.start_btn {
-  background-color: #0070f3;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-}
-.stop_btn {
-  background-color: #ff5858;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-}
 </style>

--- a/app/javascript/components/NumberAssignmentRoulette.vue
+++ b/app/javascript/components/NumberAssignmentRoulette.vue
@@ -1,6 +1,9 @@
 <template>
   <div class="mb-3">
-    <div class="fs-5">番号指定</div>
+    <div>
+      <span class="fs-5">番号指定</span>
+      <span @click="clickEvent">?</span>
+    </div>
     <div class="row">
       <div class="col-11 p-2 number_assignment_roulette">
         {{ numbering }}
@@ -34,6 +37,7 @@ export default {
       is_active: false,
     };
   },
+  emits: ["openModal"],
   methods: {
     assignNumber: function () {
       const numberings = [
@@ -60,6 +64,9 @@ export default {
           clearInterval(roulette);
         }
       }, 100);
+    },
+    clickEvent() {
+      this.$emit("openModal");
     },
   },
 };

--- a/app/javascript/components/NumberAssignmentRoulette.vue
+++ b/app/javascript/components/NumberAssignmentRoulette.vue
@@ -35,6 +35,7 @@ export default {
     return {
       numbering: {},
       is_active: false,
+      roulette_type: "number_assignment",
     };
   },
   emits: ["openModal"],
@@ -66,7 +67,7 @@ export default {
       }, 100);
     },
     clickEvent() {
-      this.$emit("openModal");
+      this.$emit("openModal", this.roulette_type);
     },
   },
 };

--- a/app/javascript/components/TalkOrderRoulette.vue
+++ b/app/javascript/components/TalkOrderRoulette.vue
@@ -77,16 +77,4 @@ export default {
   font-weight: bold;
   text-align: center;
 }
-.start_btn {
-  background-color: #0070f3;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-}
-.stop_btn {
-  background-color: #ff5858;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-}
 </style>

--- a/app/javascript/components/TalkOrderRoulette.vue
+++ b/app/javascript/components/TalkOrderRoulette.vue
@@ -1,6 +1,9 @@
 <template>
   <div>
-    <div class="fs-5">トーク順番</div>
+    <div>
+      <span class="fs-5">トーク順番</span>
+      <span @click="clickEvent">?</span>
+    </div>
     <div class="row">
       <div class="col-9 p-2 talk_order_roulette">
         {{ talk_order }}
@@ -31,6 +34,7 @@ export default {
   props: {
     number_of_people: "",
   },
+  emits: ["openModal"],
   data() {
     return {
       talk_order: {},
@@ -49,7 +53,12 @@ export default {
         talk_orders.push("1の人から", "2の人から");
       } else {
         for (let n = 1; n <= this.number_of_people; n++) {
-          talk_orders.push(`${n}の人から右回り`, `${n}の人から左回り`,`${n}から昇順`,`${n}から降順`);
+          talk_orders.push(
+            `${n}の人から右回り`,
+            `${n}の人から左回り`,
+            `${n}から昇順`,
+            `${n}から降順`
+          );
         }
       }
       this.talk_order =
@@ -66,6 +75,9 @@ export default {
           clearInterval(roulette);
         }
       }, 100);
+    },
+    clickEvent() {
+      this.$emit('openModal')
     },
   },
 };

--- a/app/javascript/components/TalkOrderRoulette.vue
+++ b/app/javascript/components/TalkOrderRoulette.vue
@@ -39,6 +39,7 @@ export default {
     return {
       talk_order: {},
       is_active: false,
+      roulette_type: "talk_order",
     };
   },
   watch: {
@@ -77,7 +78,7 @@ export default {
       }, 100);
     },
     clickEvent() {
-      this.$emit('openModal')
+      this.$emit("openModal", this.roulette_type);
     },
   },
 };

--- a/app/javascript/components/TalkOrderRoulette.vue
+++ b/app/javascript/components/TalkOrderRoulette.vue
@@ -1,26 +1,24 @@
 <template>
-  <div>
-    <div>
-      <span class="fs-5">トーク順番</span>
-      <span @click="clickEvent">?</span>
+  <div class="mb-2">
+    <span class="fs-5 me-2">トーク順番</span>
+    <span class="modal_btn" @click="clickEvent">?</span>
+  </div>
+  <div class="row">
+    <div class="col-9 p-2 talk_order_roulette">
+      {{ talk_order }}
     </div>
-    <div class="row">
-      <div class="col-9 p-2 talk_order_roulette">
-        {{ talk_order }}
+    <div
+      class="col-2 text-white px-0"
+      @click="
+        roulette();
+        active();
+      "
+    >
+      <div class="start_btn h-100" v-if="this.is_active">
+        <i class="fas fa-stop-circle"></i>
       </div>
-      <div
-        class="col-2 text-white px-0"
-        @click="
-          roulette();
-          active();
-        "
-      >
-        <div class="start_btn h-100" v-if="this.is_active">
-          <i class="fas fa-stop-circle"></i>
-        </div>
-        <div class="stop_btn h-100" v-else>
-          <i class="fas fa-sync-alt"></i>
-        </div>
+      <div class="stop_btn h-100" v-else>
+        <i class="fas fa-sync-alt"></i>
       </div>
     </div>
   </div>

--- a/app/javascript/components/TalkThemeRoulette.vue
+++ b/app/javascript/components/TalkThemeRoulette.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="fs-5 mb-3">カテゴリーを選んでください</div>
+  <div class="fs-5 mb-3">カテゴリーを選んでください。</div>
   <div class="d-flex flex-wrap mb-3">
     <div
       class="me-3"

--- a/app/javascript/end_user/HowToUsePage.vue
+++ b/app/javascript/end_user/HowToUsePage.vue
@@ -4,114 +4,78 @@
     <div class="row">
       <div class="col-12 col-lg-7 mx-auto">
         <head-line>TALK THEME</head-line>
-        <div class="description d-flex flex-column mx-auto mb-5">
-          <div class="mb-3">
-            <div class="mb-2">
-              1.お好きなトークテーマカテゴリーを選択します。
-              <div class="fw-normal">※選択したボタンは色が変わります。</div>
-            </div>
-            <div class="d-flex flex-wrap">
-              <div
-                class="me-3"
-                v-for="(category, index) in categories"
-                :key="category.id"
+        <ol class="description mx-auto mb-5">
+          <li class="mb-3">
+            お好きなトークテーマのカテゴリーを選択します。
+            <div class="fw-normal">※選択したボタンは色が変わります。</div>
+          </li>
+          <div class="d-flex flex-wrap mb-3">
+            <div
+              class="me-3"
+              v-for="(category, index) in categories"
+              :key="category.id"
+            >
+              <input
+                type="radio"
+                class="btn-check"
+                name="category"
+                :id="[`category` + index]"
+                :value="category.id"
+                v-model="category_id"
+                autocomplete="off"
+              />
+              <label
+                class="btn btn-outline-secondary category_btn"
+                :for="[`category` + index]"
+                >{{ category.name }}</label
               >
-                <input
-                  type="radio"
-                  class="btn-check"
-                  name="category"
-                  :id="[`category` + index]"
-                  :value="category.id"
-                  v-model="category_id"
-                  autocomplete="off"
-                />
-                <label
-                  class="btn btn-outline-secondary category_btn"
-                  :for="[`category` + index]"
-                  >{{ category.name }}</label
-                >
-              </div>
             </div>
           </div>
-          <div class="mb-3">
-            <div class="mb-2">
-              2. ルーレットの右にあるボタンを押します。
-              <div class="fw-normal">※トークテーマルーレットのボタンは下にあります。</div>
-            </div>
-            <div class="row">
-              <div class="d-flex col-12 col-lg-6 mb-3 fw-normal">
-                <div class="stop_btn">
-                  <i class="fas fa-sync-alt"></i>
-                </div>
-                <span class="p-2">スタートボタン</span>
-              </div>
-              <div class="d-flex col-12 col-lg-6 mb-3 fw-normal">
-                <div class="start_btn">
-                  <i class="fas fa-stop-circle"></i>
-                </div>
-                <span class="p-2">ストップボタン</span>
-              </div>
-            </div>
-          </div>
-          <div>3. 止まったテーマでトークをします。</div>
-        </div>
+          <li>
+            ルーレットの下に配置したボタンでルーレットをスタート・ストップさせ、<br />
+            トークテーマを決定し、会話を始めます。
+          </li>
+        </ol>
         <head-line>TALK SUPPORT</head-line>
-        <div class="description mx-auto mb-5">
-          <div class="mb-3">
-            <div class="mb-2">
-              1. トーク人数のボタンを押します。
-              <div class="fw-normal">※選択したボタンは色が変わります。</div>
-            </div>
-            <div class="d-flex flex-wrap justify-content-start">
-              <div class="me-3" v-for="n in 9" :key="n">
-                <input
-                  type="radio"
-                  class="btn-check"
-                  :name="n + 1"
-                  :id="n + 1"
-                  :value="n + 1"
-                  v-model="number_of_people"
-                  autocomplete="off"
-                />
-                <label
-                  class="btn btn-outline-secondary number_btn mb-3"
-                  :for="n + 1"
-                  >{{ n + 1 }}</label
-                >
-              </div>
+        <ol class="description mx-auto mb-5">
+          <li class="mb-3">
+            トーク人数を選択します。
+            <div class="fw-normal">※選択したボタンは色が変わります。</div>
+          </li>
+          <div class="d-flex flex-wrap justify-content-start mb-3">
+            <div class="me-3" v-for="n in 9" :key="n">
+              <input
+                type="radio"
+                class="btn-check"
+                :name="n + 1"
+                :id="n + 1"
+                :value="n + 1"
+                v-model="number_of_people"
+                autocomplete="off"
+              />
+              <label
+                class="btn btn-outline-secondary number_btn mb-3"
+                :for="n + 1"
+                >{{ n + 1 }}</label
+              >
             </div>
           </div>
-          <div class="mb-3">
-            2. 番号指定ルーレットの指示に従って、各参加者に番号を振ります。
-          </div>
-          <div class="mb-3">
-            3. 使いたいトークサポートルーレットを回します。
-          </div>
-          <div class="mb-3">
-            <div class="mb-2">
-              <div>トーク順番ルーレット</div>
-              <div class="fw-normal">
-                番号指定ルーレットで決めた番号をもとにトーク順番を決定します。
-              </div>
-            </div>
-            <div>
-              <div>司会者ルーレット</div>
-              <div class="fw-normal">
-                司会者を決めるためのルーレットです。<br />
-                司会者とは、なっていますが、発表者を決める際などにも使用できます。<br />
-                ※2人の時は、司会者ルーレットは表示されません。
-              </div>
-            </div>
-          </div>
-          <div>4. 止まった指示に従って、トークをします。</div>
-        </div>
-        <div class="text-center mb-3">
-          <router-link class="py-1" to="/content"
-            >トークテーマの確認はこちらから。</router-link
-          >
-        </div>
-        <roulette-page-back-button></roulette-page-back-button>
+          <li class="mb-3">
+            番号指定/トーク順番/司会者・話し手指定ルーレットは右に配置したボタンでルーレットをスタート・ストップさせます。
+          </li>
+          <li>
+            トーク順番ルーレットの指示と番号指定ルーレットで決めた番号をもとにトークの順番を決めます。<br />
+            <br />
+            また、司会者・話し手指定ルーレットにより、司会者や話し手を番号指定ルーレットで決めた番号をもとに指定することができます。
+          </li>
+        </ol>
       </div>
+      <div class="text-center mb-3">
+        <router-link class="py-1" to="/content"
+          >トークテーマの確認はこちらから。</router-link
+        >
+      </div>
+      <roulette-page-back-button></roulette-page-back-button>
     </div>
   </main>
   <end-user-footer>
@@ -164,21 +128,5 @@ export default {
 .number_btn {
   border-radius: 10px;
   font-weight: bold;
-}
-.start_btn {
-  background-color: #0070f3;
-  width: 40px;
-  color: #fff;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-}
-.stop_btn {
-  background-color: #ff5858;
-  color: #fff;
-  width: 40px;
-  display: flex;
-  justify-content: center;
-  align-items: center;
 }
 </style>

--- a/app/javascript/end_user/RoulettePage.vue
+++ b/app/javascript/end_user/RoulettePage.vue
@@ -88,9 +88,21 @@ export default {
 };
 </script>
 
-<style scoped>
+<style>
 .number_btn {
   border-radius: 10px;
   font-weight: bold;
+}
+.start_btn {
+  background-color: #0070f3;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+.stop_btn {
+  background-color: #ff5858;
+  display: flex;
+  justify-content: center;
+  align-items: center;
 }
 </style>

--- a/app/javascript/end_user/RoulettePage.vue
+++ b/app/javascript/end_user/RoulettePage.vue
@@ -1,4 +1,10 @@
 <template>
+  <div v-if="showContent" id="overlay">
+    <div id="content">
+      <p>これがモーダルウィンドウです。</p>
+      <p><button @click="closeModal">close</button></p>
+    </div>
+  </div>
   <Header>B I L B I L</Header>
   <main class="container my-5">
     <div class="row">
@@ -21,7 +27,7 @@
         </div>
         <div class="px-1">
           <head-line>TALK SUPPORT</head-line>
-          <div class="fs-5 mb-2">トーク人数を選んでください</div>
+          <div class="fs-5 mb-2">トーク人数を選んでください。</div>
           <div class="d-flex flex-wrap justify-content-start">
             <div class="me-3" v-for="n in 9" :key="n">
               <input
@@ -40,15 +46,19 @@
               >
             </div>
           </div>
-          <number-assignment-roulette></number-assignment-roulette>
+          <number-assignment-roulette @openModal="openModal"></number-assignment-roulette>
           <div class="row">
             <div class="col-7">
               <talk-order-roulette
                 :number_of_people="number_of_people"
+                @openModal="openModal"
               ></talk-order-roulette>
             </div>
             <div class="col-5">
-              <host-roulette :number_of_people="number_of_people"></host-roulette>
+              <host-roulette
+                :number_of_people="number_of_people"
+                @openModal="openModal"
+              ></host-roulette>
             </div>
           </div>
         </div>
@@ -83,12 +93,39 @@ export default {
   data() {
     return {
       number_of_people: 2,
+      showContent: false,
     };
+  },
+  methods: {
+    openModal() {
+      this.showContent = true;
+    },
+    closeModal() {
+      this.showContent = false;
+    },
   },
 };
 </script>
 
 <style>
+#overlay {
+  z-index: 1;
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+#content {
+  z-index: 2;
+  width: 50%;
+  padding: 1em;
+  background: #fff;
+}
 .number_btn {
   border-radius: 10px;
   font-weight: bold;

--- a/app/javascript/end_user/RoulettePage.vue
+++ b/app/javascript/end_user/RoulettePage.vue
@@ -20,7 +20,7 @@
           <head-line>TALK THEME</head-line>
           <talk-theme-roulette></talk-theme-roulette>
         </div>
-        <div class="mb-3">
+        <div class="mb-5">
           <head-line>TALK SUPPORT</head-line>
           <div class="fs-5 mb-2">トーク人数を選んでください。</div>
           <div class="d-flex flex-wrap justify-content-start">
@@ -56,6 +56,9 @@
               ></host-roulette>
             </div>
           </div>
+        </div>
+        <div class="fs-5">
+          はてなボタンを押すと、各ルーレットの説明が開きます。
         </div>
       </div>
     </div>

--- a/app/javascript/end_user/RoulettePage.vue
+++ b/app/javascript/end_user/RoulettePage.vue
@@ -1,9 +1,9 @@
 <template>
   <Header>B I L B I L</Header>
   <main class="container my-5">
-    <modal-window :show_content="show_content" :roulette_type="roulette_type"  @closeModal="closeModal"></modal-window>
+    <modal-window :show_content="show_content" :roulette_type="roulette_type" @closeModal="closeModal"></modal-window>
     <div class="row">
-      <div class="col-12 col-sm-7 mx-auto">
+      <div class="col-12 col-md-7 mx-auto">
         <div class="mb-3">
           <div class="mb-2">
             <router-link class="py-1" to="/guide"
@@ -16,11 +16,11 @@
             >
           </div>
         </div>
-        <div class="px-1 mb-5">
+        <div class="mb-5">
           <head-line>TALK THEME</head-line>
           <talk-theme-roulette></talk-theme-roulette>
         </div>
-        <div class="px-1">
+        <div class="mb-3">
           <head-line>TALK SUPPORT</head-line>
           <div class="fs-5 mb-2">トーク人数を選んでください。</div>
           <div class="d-flex flex-wrap justify-content-start">
@@ -43,13 +43,13 @@
           </div>
           <number-assignment-roulette @openModal="openModal"></number-assignment-roulette>
           <div class="row">
-            <div class="col-7">
+            <div class="col-6">
               <talk-order-roulette
                 :number_of_people="number_of_people"
                 @openModal="openModal"
               ></talk-order-roulette>
             </div>
-            <div class="col-5">
+            <div class="col-6">
               <host-roulette
                 :number_of_people="number_of_people"
                 @openModal="openModal"
@@ -107,6 +107,11 @@ export default {
 </script>
 
 <style>
+.modal_btn {
+  padding: 5px 10px;
+  border: solid 1px #6C757D;
+  cursor: pointer;
+}
 .number_btn {
   border-radius: 10px;
   font-weight: bold;

--- a/app/javascript/end_user/RoulettePage.vue
+++ b/app/javascript/end_user/RoulettePage.vue
@@ -1,12 +1,7 @@
 <template>
-  <div v-if="showContent" id="overlay">
-    <div id="content">
-      <p>これがモーダルウィンドウです。</p>
-      <p><button @click="closeModal">close</button></p>
-    </div>
-  </div>
   <Header>B I L B I L</Header>
   <main class="container my-5">
+    <modal-window :show_content="show_content" :roulette_type="roulette_type"  @closeModal="closeModal"></modal-window>
     <div class="row">
       <div class="col-12 col-sm-7 mx-auto">
         <div class="mb-3">
@@ -72,6 +67,7 @@
 </template>
 
 <script>
+import ModalWindow from "../components/ModalWindow.vue";
 import Header from "../components/Header.vue";
 import HeadLine from "../components/Headline.vue";
 import TalkThemeRoulette from "../components/TalkThemeRoulette.vue";
@@ -82,6 +78,7 @@ import EndUserFooter from "../components/EndUserFooter.vue";
 
 export default {
   components: {
+    ModalWindow,
     Header,
     HeadLine,
     TalkThemeRoulette,
@@ -93,39 +90,23 @@ export default {
   data() {
     return {
       number_of_people: 2,
-      showContent: false,
+      show_content: false,
+      roulette_type: "",
     };
   },
   methods: {
-    openModal() {
-      this.showContent = true;
+    openModal(roulette_type) {
+      this.show_content = true;
+      this.roulette_type = roulette_type;
     },
     closeModal() {
-      this.showContent = false;
+      this.show_content = false;
     },
   },
 };
 </script>
 
 <style>
-#overlay {
-  z-index: 1;
-  position: fixed;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  background-color: rgba(0, 0, 0, 0.5);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-#content {
-  z-index: 2;
-  width: 50%;
-  padding: 1em;
-  background: #fff;
-}
 .number_btn {
   border-radius: 10px;
   font-weight: bold;


### PR DESCRIPTION
## 変更の概要
会話サポートルーレットの説明をモーダルウィンドウで表示できるようにする。

## なぜこの変更をするのか
会話サポートルーレットの使い方をより気軽に知ることができるようにするため。

## やったこと
1. モーダルウィンドウを追加する。
2. 会話サポートルーレットの各ルーレットの横にモーダルウィンドウを表示させるためのボタンを用意する。
3. モーダルウィンドウの中に各ルーレットの説明を書く。

## 関連issue
- #52 