### PR TITLE
perf: コンテンツ一覧画面にあるいいねボタン数の分、APIが叩かれてしまう問題を解決する。

### DIFF
--- a/app/controllers/api/v1/likes_controller.rb
+++ b/app/controllers/api/v1/likes_controller.rb
@@ -17,7 +17,8 @@ class Api::V1::LikesController < ApiController
 
   def ip
     likes = Like.where(ip: request.remote_ip)
-    render json: likes, each_serializer: LikeSerializer
+    liked_talk_theme_ids = likes.map { |like| like.talk_theme_id }
+    render json: liked_talk_theme_ids
   end
 
   def create

--- a/app/javascript/end_user/ContentIndexPage.vue
+++ b/app/javascript/end_user/ContentIndexPage.vue
@@ -1,8 +1,9 @@
 <template>
   <Header>C O N T E N T</Header>
   <main class="container">
-    <div class="row my-5">
+    <div class="row mx-2 my-5">
       <div class="col-lg-7 mx-auto">
+        <!-- ページ説明文 -->
         <div class="mb-3">
           <div class="mb-2">
             このアプリで出題されるトークテーマを各カテゴリーごと
@@ -11,17 +12,23 @@
           <div class="mb-2">
             また、トークテーマにいいねをすることができます。
           </div>
-          <div class="mb-2">
+          <div>
             いいねをしたトークテーマは各カテゴリーのトークテーマ一覧の上部に表示されます。
           </div>
         </div>
-        <div class="mb-3 text-center">
-          <router-link class="py-1" to="/guide"
-            >ご利用ガイドはこちらから。</router-link
-          >
+        <!-- /ページ説明文 -->
+        <!-- ページ遷移リンク -->
+        <div class="mb-3">
+          <div class="mb-2 text-center">
+            <router-link class="py-1" to="/guide"
+              >ご利用ガイドはこちらから。</router-link
+            >
+          </div>
+          <roulette-page-back-button></roulette-page-back-button>
         </div>
-        <roulette-page-back-button></roulette-page-back-button>
-        <div class="mt-5">
+        <!-- /ページ遷移リンク -->
+        <!-- 各カテゴリーのトークテーマ一覧 -->
+        <div class="mb-3">
           <div
             class="row dropdown"
             v-for="category in categories"
@@ -29,7 +36,7 @@
           >
             <button
               type="button"
-              class="btn btn-dark dropdown-toggle py-2"
+              class="btn btn-dark dropdown-toggle"
               data-bs-toggle="dropdown"
               data-bs-auto-close="false"
             >
@@ -39,33 +46,35 @@
             </button>
             <ol class="dropdown-menu p-0">
               <li
-                v-for="(talk_theme, index) in category.talk_themes"
-                :key="talk_theme.id"
                 v-if="category.talk_themes.length != 0"
+                v-for="talk_theme in category.talk_themes"
+                :key="talk_theme.id"
                 class="dropdown-item"
               >
-                <dl class="row d-inline-flex flex-wrap m-0">
-                  <dt class="col-12 col-sm-11 text-wrap">
+                <div class="row d-inline-flex flex-wrap">
+                  <div class="col-9 fw-bold text-wrap">
                     {{ talk_theme.content }} ?
-                  </dt>
-                  <dd class="col-1">
+                  </div>
+                  <div class="col-3">
                     <talk-theme-like-button
                       :talk_theme_id="talk_theme.id"
                       :likes="talk_theme.likes"
-                      @fetchCategories="fetchCategories"
-                      @fetchLikesByIpAddress="fetchLikesByIpAddress"
+                      :liked_talk_theme_ids="this.liked_talk_theme_ids"
+                      @addLikedTalkTheme="addLikedTalkTheme"
+                      @removeLikedTalkTheme="removeLikedTalkTheme"
                     ></talk-theme-like-button>
-                  </dd>
-                </dl>
+                  </div>
+                </div>
               </li>
-              <li class="d-block px-1 py-2" v-else>
-                <dl class="m-0">
-                  <dt>トークテーマはありません。</dt>
-                </dl>
+              <li v-else>
+                <div class="fw-bold p-2">
+                  トークテーマはありません。
+                </div>
               </li>
             </ol>
           </div>
         </div>
+        <!-- /各カテゴリーのトークテーマ一覧 -->
       </div>
     </div>
   </main>
@@ -90,18 +99,27 @@ export default {
     RoulettePageBackButton,
     EndUserFooter,
   },
+  created() {
+    this.fetchCategories();
+    this.fetchLikedTalkThemeIds();
+  },
   data() {
     return {
-      categories: {},
-      liked_talk_theme_ids: [],
+      categories: [], // 全カテゴリーのデータの配列。
+      liked_talk_theme_ids: [], // いいねをしたトークテーマのidの配列。
     };
   },
-  created() {
-    this.fetchLikesByIpAddress();
-    this.fetchCategories();
+  watch: {
+    //いいねをしたトークテーマのidの配列に変化があった時、トークテーマの並び替えを行う。
+    liked_talk_theme_ids: {
+      handler() {
+        this.sortedTalkThemesByLikes;
+      },
+      deep: true,
+    },
   },
   computed: {
-    // カテゴリー一覧の順番を並び替える。
+    // いいねをしたトークテーマをトークテーマ一覧の上部に表示させる。
     sortedTalkThemesByLikes() {
       const ids = this.liked_talk_theme_ids;
 
@@ -119,19 +137,31 @@ export default {
     },
   },
   methods: {
-    // カテゴリー一覧を取得し、その順番を並び替える。
+    // 全カテゴリーのデータを取得し、トークテーマの並び替えを行う。
     fetchCategories() {
       axios.get("/api/v1/categories").then((response) => {
         this.categories = response.data;
-        this.categories = this.sortedTalkThemesByLikes();
+        this.sortedTalkThemesByLikes;
       });
     },
 
-    // 接続しているipアドレスがipカラムに保存されているいいねを取得する。
-    fetchLikesByIpAddress() {
+    // 接続しているipアドレスをipカラムに保存しているいいねレコードのトークテーマidカラムの値を配列にし、取得する。
+    
+    fetchLikedTalkThemeIds() {
       axios.get("/api/v1/like/ip").then((response) => {
         this.liked_talk_theme_ids = response.data;
       });
+    },
+
+    // いいねをしたトークテーマのidの配列に、新たにいいねをしたトークテーマのidを追加する。
+    addLikedTalkTheme(talk_theme_id) {
+      this.liked_talk_theme_ids.push(talk_theme_id);
+    },
+
+    // いいねをしたトークテーマのidの配列から、いいねを解除したトークテーマのidを削除する。
+    removeLikedTalkTheme(talk_theme_id) {
+      const ids = this.liked_talk_theme_ids.filter((id) => id != talk_theme_id);
+      this.liked_talk_theme_ids = ids;
     },
   },
 };

--- a/app/javascript/end_user/ContentIndexPage.vue
+++ b/app/javascript/end_user/ContentIndexPage.vue
@@ -93,49 +93,44 @@ export default {
   data() {
     return {
       categories: {},
-      liked_talk_themes: [],
+      liked_talk_theme_ids: [],
     };
   },
   created() {
     this.fetchLikesByIpAddress();
     this.fetchCategories();
   },
+  computed: {
+    // カテゴリー一覧の順番を並び替える。
+    sortedTalkThemesByLikes() {
+      const ids = this.liked_talk_theme_ids;
+
+      return this.categories.forEach((category) => {
+        category.talk_themes.sort((a, b) => {
+          if (ids.includes(a.id)) {
+            return -1;
+          } else if (ids.includes(b.id)) {
+            return 1;
+          } else {
+            return 0;
+          }
+        });
+      });
+    },
+  },
   methods: {
     // カテゴリー一覧を取得し、その順番を並び替える。
-    fetchCategories: function () {
+    fetchCategories() {
       axios.get("/api/v1/categories").then((response) => {
         this.categories = response.data;
         this.categories = this.sortedTalkThemesByLikes();
       });
     },
 
-    // カテゴリー一覧の順番を並び替える。
-    sortedTalkThemesByLikes: function () {
-      const talk_theme_ids = [];
-      this.liked_talk_themes.forEach((like) => {
-        talk_theme_ids.push(like.talk_theme_id);
-      });
-
-      const talk_themes_sorted = [];
-      this.categories.forEach((category) => {
-        category.talk_themes.sort((a, b) => {
-          if (talk_theme_ids.includes(a.id)) {
-            return -1;
-          } else if (talk_theme_ids.includes(b.id)) {
-            return 1;
-          } else {
-            return 0;
-          }
-        });
-        talk_themes_sorted.push(category);
-      });
-      return talk_themes_sorted;
-    },
-
     // 接続しているipアドレスがipカラムに保存されているいいねを取得する。
     fetchLikesByIpAddress() {
       axios.get("/api/v1/like/ip").then((response) => {
-        this.liked_talk_themes = response.data;
+        this.liked_talk_theme_ids = response.data;
       });
     },
   },


### PR DESCRIPTION
## 変更の概要
コンテンツ一覧画面にあるいいねボタン数の分、APIが叩かれてしまう問題を解決する。

## なぜこの変更をするのか
APIを叩く回数が多くなると、その分読み込み速度が遅くなってしまうため。

## やったこと
1. 最初にAPIでいいねをしているトークテーマのidの配列を取得し、それを元にいいねボタンの表示を変化させるようにする。
2. いいねをしたトークテーマのidは1の配列に追加し、いいねを解除したトークテーマのidは1の配列から削除するようにする。
3. いいねをした際にトークテーマのいいね数に1加え、いいねを解除した際にトークテーマのいいね数を1減らすようにする。

## 関連issue
- #56 