### PR TITLE
feat: いいね数が多いトークテーマをトークテーマルーレットで出しやすくする。

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ https://bil-bil.herokuapp.com/
 ## **使用技術** 🛠️
 **フロントエンド** <br/>
 HTML/CSS/Bootstrap5<br/>
-Vue.js 3.2.36
+Vue.js 3.2.36 (JavaScript)
 
 **バックエンド**<br/>
 Ruby 3.1.2<br/>

--- a/app/controllers/api/v1/likes_controller.rb
+++ b/app/controllers/api/v1/likes_controller.rb
@@ -1,6 +1,4 @@
 class Api::V1::LikesController < ApiController
-  before_action :set_like, only: [:judge, :destroy]
-
   # ActiveRecordのレコードが見つからなければ404 not foundを応答する
   rescue_from ActiveRecord::RecordNotFound do |exception|
     render json: { error: '404 not found' }, status: 404
@@ -9,10 +7,6 @@ class Api::V1::LikesController < ApiController
   def show
     likes = Like.where(talk_theme_id: params[:talk_theme_id])
     render json: likes, each_serializer: LikeSerializer
-  end
-
-  def judge
-    render json: @like
   end
 
   def ip
@@ -28,13 +22,8 @@ class Api::V1::LikesController < ApiController
   end
 
   def destroy
-    @like.destroy
+    like = Like.find_by(ip: request.remote_ip, talk_theme_id: params[:talk_theme_id])
+    like.destroy
     head :no_content
-  end
-
-  private
-  # @likeは再使用できるので、メソッドにしておく。
-  def set_like
-    @like = Like.find_by(ip: request.remote_ip, talk_theme_id: params[:talk_theme_id])
   end
 end

--- a/app/javascript/components/TalkThemeRoulette.vue
+++ b/app/javascript/components/TalkThemeRoulette.vue
@@ -110,7 +110,6 @@ export default {
       for (const talk_theme in up_to_the_tenth) {
         // ランダムに0~100をrandに代入する。
         const rand = Math.floor(Math.random() * 100);
-        console.log(rand);
 
         // もしrandの数値がトークテーマに付与された数値以下だったら、そのトークテーマをresultに代入する。
         if (rand <= up_to_the_tenth[talk_theme]) {

--- a/app/javascript/components/TalkThemeRoulette.vue
+++ b/app/javascript/components/TalkThemeRoulette.vue
@@ -28,7 +28,7 @@
   <div class="fs-5">{{ this.category_name }}トーク</div>
   <div class="talk_theme_roulette mb-3">
     <span class="m-4" v-if="this.talk_theme != undefined">
-      {{ talk_theme.content }} ?
+      {{ talk_theme }} ?
     </span>
     <span v-else>トークはありません。</span>
   </div>
@@ -61,15 +61,10 @@ import axios from "axios";
 export default {
   created() {
     // 全カテゴリーのデータを取得し、dataのcategory_idにindexが0のカテゴリーのidを代入する。
-    axios
-      .get("/api/v1/categories")
-      .then((response) => {
-        this.categories = response.data;
-        this.category_id = this.categories[0].id;
-      })
-      .then(() => {
-        this.talkThemes();
-      });
+    axios.get("/api/v1/categories").then((response) => {
+      this.categories = response.data;
+      this.category_id = this.categories[0].id;
+    });
   },
   data() {
     return {
@@ -92,13 +87,38 @@ export default {
       const selected_category = this.categories.find(
         (category) => category.id == this.category_id
       );
+      const talk_themes = selected_category.talk_themes;
 
       // 選択したカテゴリーのカテゴリー名を取得する。
       this.category_name = selected_category.name;
 
-      // ルーレット内容の配列から1つランダムに表示させる。
-      this.talk_theme =
-        selected_category.talk_themes[Math.floor(Math.random() * selected_category.talk_themes.length)];
+      // 各カテゴリーの人気トークテーマの10番目までを取得する。
+      let up_to_the_tenth = {};
+      for (const index in talk_themes) {
+        if (index < 10) {
+          // 「"トークテーマ": 30」をup_to_the_tenthに格納する。
+          up_to_the_tenth[talk_themes[index].content] = 30;
+        } else {
+          break;
+        }
+      }
+
+      // トークテーマをランダムにresultに代入する。
+      let result =
+        talk_themes[Math.floor(Math.random() * talk_themes.length)].content;
+
+      for (const talk_theme in up_to_the_tenth) {
+        // ランダムに0~100をrandに代入する。
+        const rand = Math.floor(Math.random() * 100);
+        console.log(rand);
+
+        // もしrandの数値がトークテーマに付与された数値以下だったら、そのトークテーマをresultに代入する。
+        if (rand <= up_to_the_tenth[talk_theme]) {
+          result = talk_theme;
+          break;
+        }
+      }
+      this.talk_theme = result;
     },
 
     // ルーレットのボタンを切り替える。

--- a/app/javascript/components/TalkThemeRoulette.vue
+++ b/app/javascript/components/TalkThemeRoulette.vue
@@ -89,16 +89,16 @@ export default {
   methods: {
     talkThemes() {
       // 選択したカテゴリーのルーレット内容を配列にする。
-      const category = this.categories.find(
+      const selected_category = this.categories.find(
         (category) => category.id == this.category_id
       );
 
       // 選択したカテゴリーのカテゴリー名を取得する。
-      this.category_name = category.name;
+      this.category_name = selected_category.name;
 
       // ルーレット内容の配列から1つランダムに表示させる。
       this.talk_theme =
-        category.talk_themes[Math.floor(Math.random() * category.talk_themes.length)];
+        selected_category.talk_themes[Math.floor(Math.random() * selected_category.talk_themes.length)];
     },
 
     // ルーレットのボタンを切り替える。

--- a/app/javascript/components/TalkThemeRoulette.vue
+++ b/app/javascript/components/TalkThemeRoulette.vue
@@ -89,6 +89,11 @@ export default {
       );
       const talk_themes = selected_category.talk_themes;
 
+      // トークテーマをいいね数が多い順に並び替える。
+      talk_themes.sort((a, b) => {
+        return b.likes.length - a.likes.length;
+      });
+
       // 選択したカテゴリーのカテゴリー名を取得する。
       this.category_name = selected_category.name;
 

--- a/app/javascript/components/TalkThemeRoulette.vue
+++ b/app/javascript/components/TalkThemeRoulette.vue
@@ -26,7 +26,7 @@
   <!-- /カテゴリー選択ボタン -->
   <!-- ルーレット表示部分 -->
   <div class="fs-5">{{ this.category_name }}トーク</div>
-  <div class="talk_theme_roulette mb-3 fs-5">
+  <div class="talk_theme_roulette mb-3">
     <span class="m-4" v-if="this.talk_theme != undefined">
       {{ talk_theme.content }} ?
     </span>
@@ -69,14 +69,13 @@ export default {
       })
       .then(() => {
         this.talkThemes();
-        this.getCategoryName();
       });
   },
   data() {
     return {
       categories: [], // 全カテゴリーのデータの配列。
       category_id: "", // 選択されたカテゴリーのid。
-      category_name:"", // 選択されたカテゴリーの名前。
+      category_name: "", // 選択されたカテゴリーのカテゴリー名。
       talk_theme: {}, // ルーレットに表示されるトークテーマ。
       is_active: false, // ルーレットボタンの切り替え。
     };
@@ -85,33 +84,21 @@ export default {
     // 選択したカテゴリーが変わるごとに、ルーレットの内容と取得するカテゴリー名を変更する。
     category_id: function () {
       this.talkThemes();
-      this.getCategoryName();
     },
   },
   methods: {
-    // ルーレットの内容の配列を作成し、その配列からランダムで1つデータを表示させる。
     talkThemes() {
-      let talk_themes = [];
-      this.categories.forEach((category) => {
-        if (category.id == this.category_id) {
-          talk_themes = category.talk_themes;
-          this.talk_theme =
-            talk_themes[Math.floor(Math.random() * talk_themes.length)];
-        }
-      });
-    },
+      // 選択したカテゴリーのルーレット内容を配列にする。
+      const category = this.categories.find(
+        (category) => category.id == this.category_id
+      );
 
-    // 選択したカテゴリーのカテゴリー名を取得する。
-    async getCategoryName() {
-      const category = await this.category();
+      // 選択したカテゴリーのカテゴリー名を取得する。
       this.category_name = category.name;
-    },
-    category() {
-      return new Promise((resolve) => {
-        resolve(
-          this.categories.find((category) => category.id == this.category_id)
-        );
-      });
+
+      // ルーレット内容の配列から1つランダムに表示させる。
+      this.talk_theme =
+        category.talk_themes[Math.floor(Math.random() * category.talk_themes.length)];
     },
 
     // ルーレットのボタンを切り替える。
@@ -146,6 +133,7 @@ export default {
   border: 1px solid #000;
   border-radius: 5px;
   font-weight: bold;
+  font-size: 1.25rem;
   height: 200px;
 }
 .start_btn {

--- a/app/javascript/end_user/ContentIndexPage.vue
+++ b/app/javascript/end_user/ContentIndexPage.vue
@@ -70,9 +70,7 @@
               <!-- /トークテーマが存在する場合 -->
               <!-- トークテーマが存在しない場合 -->
               <li v-else>
-                <div class="fw-bold p-2">
-                  トークテーマはありません。
-                </div>
+                <div class="fw-bold p-2">トークテーマはありません。</div>
               </li>
               <!-- /トークテーマが存在しない場合 -->
             </ol>
@@ -117,12 +115,22 @@ export default {
     //いいねをしたトークテーマのidの配列に変化があった時、トークテーマの並び替えを行う。
     liked_talk_theme_ids: {
       handler() {
+        this.popularTalkThemes;
         this.sortedTalkThemesByLikes;
       },
       deep: true,
     },
   },
   computed: {
+    // トークテーマをいいね数が多い順に並び替える。
+    popularTalkThemes() {
+      this.categories.forEach((category) => {
+        category.talk_themes.sort((a, b) => {
+          return b.likes.length - a.likes.length;
+        });
+      });
+    },
+
     // いいねをしたトークテーマをトークテーマ一覧の上部に表示させる。
     sortedTalkThemesByLikes() {
       const ids = this.liked_talk_theme_ids;
@@ -145,6 +153,7 @@ export default {
     fetchCategories() {
       axios.get("/api/v1/categories").then((response) => {
         this.categories = response.data;
+        this.popularTalkThemes;
         this.sortedTalkThemesByLikes;
       });
     },

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,11 +20,7 @@ Rails.application.routes.draw do
     namespace :v1 do
       resources :categories, only: [:index, :create, :show, :update, :destroy]
       resources :talk_themes, only: [:index, :create, :show, :update, :destroy] do
-        resource :like, only: [:show, :create, :destroy] do
-          collection do
-            get 'judge'
-          end
-        end
+        resource :like, only: [:show, :create, :destroy]
       end
       get 'like/ip' => 'likes#ip'
     end


### PR DESCRIPTION
## 変更の概要
いいね数が多いトークテーマをトークテーマルーレットで出しやすくする。

## なぜこの変更をするのか
人気があるトークテーマの提示回数が多くなってほうがより会話を楽しめるのではないかと考えるため。（友人からの提案）

## やったこと
1. 各カテゴリーの上から10番目までのトークテーマをルーレットで出やすくするための関数を作成する。
2. トークテーマをいいね数が多い順に並ぶように変更する。

## 関連issue
- #58 