### PR TITLE
feat: 管理者ログインのE2Eテストを実装する。

### DIFF
--- a/spec/factories/admins.rb
+++ b/spec/factories/admins.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :admin do
-    email { "a@a"}
-    password { "aaaaaa" }
-    password_confirmation { "aaaaaa"}
+    email { Faker::Internet.email }
+    password { "password" }
+    password_confirmation { "password" }
   end
 end

--- a/spec/system/admin_spec.rb
+++ b/spec/system/admin_spec.rb
@@ -1,0 +1,9 @@
+require 'rails_helper'
+
+RSpec.describe "Admin", type: :system do
+  before do
+    driven_by(:rack_test)
+  end
+
+  pending "add some scenarios (or delete) #{__FILE__}"
+end

--- a/spec/system/admin_spec.rb
+++ b/spec/system/admin_spec.rb
@@ -1,9 +1,50 @@
 require 'rails_helper'
 
-RSpec.describe "Admin", type: :system do
-  before do
-    driven_by(:rack_test)
+RSpec.describe "管理者専用画面E2Eテスト", type: :system do
+  describe '管理者ログイン' do
+    let(:admin) { create(:admin) }
+    
+    before do
+      visit new_admin_session_path
+    end
+  
+    context '表示内容の確認' do
+      it 'URLが正しい' do
+        expect(current_path).to eq '/admin/sign_in'
+      end
+      it 'メールアドレス入力フォームが表示される' do
+        expect(page).to have_field 'admin[email]'
+      end
+      it 'パスワード入力フォームが表示される' do
+        expect(page).to have_field 'admin[password]'
+      end
+      it 'ログインボタンが表示される' do
+        expect(page).to have_button 'ログインする'
+      end
+    end
+  
+    context 'ログイン成功のテスト' do
+      before do
+        fill_in 'admin[email]', with: admin.email
+        fill_in 'admin[password]', with: admin.password
+        click_button 'ログインする'
+      end
+  
+      it 'ログイン後のリダイレクト先が、管理者側のコンテンツ一覧画面になっている' do
+        expect(current_path).to eq '/admin'
+      end
+    end
+  
+    context 'ログイン失敗のテスト' do
+      before do
+        fill_in 'admin[email]', with: ''
+        fill_in 'admin[password]', with: ''
+        click_button 'ログインする'
+      end
+  
+      it 'ログインに失敗し、ログイン画面にリダイレクトされる' do
+        expect(current_path).to eq '/admin/sign_in'
+      end
+    end
   end
-
-  pending "add some scenarios (or delete) #{__FILE__}"
 end


### PR DESCRIPTION
## 変更の概要
管理者ログインのE2Eテストを実装する。

## なぜこの変更をするのか
- 管理者ログインが問題なくできるかを確認するため。
- E2Eテストのコードを書いてみたいため。

## やったこと
1. E2Eテストの書き方を調べ、それに従い管理者ログインのテストコードを実装する。
2. RSpecのSystemSpecを動かすため、WSL2にchromeをインストールする。

## 関連issue
- #60 