### PR TITLE
N+1問題対策でincludesが使われている部分をpreloadやeager_loadに変更する。

### DIFF
--- a/app/controllers/api/v1/categories_controller.rb
+++ b/app/controllers/api/v1/categories_controller.rb
@@ -10,8 +10,8 @@ class Api::V1::CategoriesController < ApiController
   end
 
   def index
-    # includesでtalk_themesとlikesのデータを予め取得しておく。
-    categories = Category.includes(talk_themes: :likes).all
+    # preloadでtalk_themesとlikesのデータを予め取得しておく。
+    categories = Category.preload(talk_themes: :likes)
     render json: categories, each_serializer: CategorySerializer, include: [talk_themes: :likes]
   end
 

--- a/app/controllers/api/v1/talk_themes_controller.rb
+++ b/app/controllers/api/v1/talk_themes_controller.rb
@@ -10,8 +10,8 @@ class Api::V1::TalkThemesController < ApiController
   end
 
   def index
-    # includesでlikesのデータを予め取得しておく。
-    talk_themes = TalkTheme.includes(:likes).all
+    # preloadでlikesのデータを予め取得しておく。
+    talk_themes = TalkTheme.preload(:likes)
     render json: talk_themes, each_serializer: TalkThemeSerializer
   end
 


### PR DESCRIPTION
## 変更の概要
N+1問題対策でincludesが使われている部分をpreloadやeager_loadに変更する。

## なぜこの変更をするのか
- includesでは、データ量が増えるにつれパフォーマンスが低下する恐れがあるため。

## やったこと
1. 各コントローラでincludesが使われている部分をpreloadに変更する。

## 関連issue
- #61 